### PR TITLE
security: harden app with rate limiting, headers, and input validation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,38 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
+          {
+            key: "Content-Security-Policy",
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' data: https://lh3.googleusercontent.com",
+              "font-src 'self'",
+              "connect-src 'self'",
+              "frame-ancestors 'none'",
+            ].join("; "),
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/api/blocks/route.ts
+++ b/src/app/api/blocks/route.ts
@@ -6,6 +6,9 @@ import {
   jsonResponse,
   errorResponse,
 } from "@/lib/api-helpers";
+import { rateLimit } from "@/lib/rate-limit";
+
+const blocksLimiter = rateLimit({ key: "blocks", limit: 30, windowMs: 60_000 });
 
 export async function GET(req: Request) {
   const user = await getAuthenticatedUser();
@@ -36,9 +39,25 @@ export async function POST(req: Request) {
   const user = await getAuthenticatedUser();
   if (!user) return errorResponse("Unauthorized", 401);
 
+  const { success: withinLimit } = blocksLimiter.check(user.id);
+  if (!withinLimit) {
+    return errorResponse("Rate limit exceeded. Try again shortly.", 429);
+  }
+
   const body = await req.json();
   if (!body.title || !body.startTime || !body.endTime) {
     return errorResponse("title, startTime, and endTime are required");
+  }
+
+  const startTime = new Date(body.startTime);
+  const endTime = new Date(body.endTime);
+
+  if (isNaN(startTime.getTime()) || isNaN(endTime.getTime())) {
+    return errorResponse("startTime and endTime must be valid date strings", 400);
+  }
+
+  if (endTime <= startTime) {
+    return errorResponse("endTime must be after startTime", 400);
   }
 
   const [block] = await db
@@ -47,8 +66,8 @@ export async function POST(req: Request) {
       userId: user.id,
       taskId: body.taskId ?? null,
       title: body.title,
-      startTime: new Date(body.startTime),
-      endTime: new Date(body.endTime),
+      startTime,
+      endTime,
       blockType: body.blockType ?? "focus",
       committed: body.committed ?? false,
     })

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -10,18 +10,12 @@ import { buildSystemPrompt } from "@/lib/chat/planner-prompt";
 import { handleAction, type ActionResult } from "@/lib/chat/action-handler";
 import { dbTaskToTask, dbBlockToTimeBlock } from "@/lib/types";
 import { jsonResponse, errorResponse } from "@/lib/api-helpers";
-import { toLocalDateStr } from "@/lib/utils";
+import { toLocalDateStr, isValidTimezone } from "@/lib/utils";
 import { extractMemories, getMemoryDigest, saveMemories } from "@/lib/chat/memory";
 import { buildTieredContext } from "@/lib/chat/context-builder";
+import { rateLimit } from "@/lib/rate-limit";
 
-function isValidTimezone(tz: string): boolean {
-  try {
-    Intl.DateTimeFormat(undefined, { timeZone: tz });
-    return true;
-  } catch {
-    return false;
-  }
-}
+const chatLimiter = rateLimit({ key: "chat", limit: 20, windowMs: 60_000 });
 
 function getWeekRange() {
   const now = new Date();
@@ -50,6 +44,11 @@ export async function POST(req: Request) {
   }
 
   const userId = session.user.id;
+
+  const { success: withinLimit } = chatLimiter.check(userId);
+  if (!withinLimit) {
+    return errorResponse("Rate limit exceeded. Try again shortly.", 429);
+  }
   const weekRange = getWeekRange();
 
   // Save user message

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -6,6 +6,9 @@ import {
   jsonResponse,
   errorResponse,
 } from "@/lib/api-helpers";
+import { rateLimit } from "@/lib/rate-limit";
+
+const tasksLimiter = rateLimit({ key: "tasks", limit: 30, windowMs: 60_000 });
 
 export async function GET() {
   const user = await getAuthenticatedUser();
@@ -23,6 +26,11 @@ export async function GET() {
 export async function POST(req: Request) {
   const user = await getAuthenticatedUser();
   if (!user) return errorResponse("Unauthorized", 401);
+
+  const { success: withinLimit } = tasksLimiter.check(user.id);
+  if (!withinLimit) {
+    return errorResponse("Rate limit exceeded. Try again shortly.", 429);
+  }
 
   const body = await req.json();
   if (!body.title || typeof body.title !== "string" || body.title.length > 500) {

--- a/src/app/api/user/preferences/route.ts
+++ b/src/app/api/user/preferences/route.ts
@@ -6,6 +6,18 @@ import {
   jsonResponse,
   errorResponse,
 } from "@/lib/api-helpers";
+import { isValidTimezone } from "@/lib/utils";
+import { rateLimit } from "@/lib/rate-limit";
+
+const prefsLimiter = rateLimit({ key: "prefs", limit: 10, windowMs: 60_000 });
+
+const ALLOWED_PREFS: Record<string, (v: unknown) => boolean> = {
+  workingHoursStart: (v) => typeof v === "number" && v >= 0 && v <= 23,
+  workingHoursEnd: (v) => typeof v === "number" && v >= 0 && v <= 23,
+  lunchDurationMinutes: (v) => typeof v === "number" && v >= 0 && v <= 120,
+  maxBlockMinutes: (v) => typeof v === "number" && v >= 15 && v <= 480,
+  meetingBuffer: (v) => typeof v === "number" && v >= 0 && v <= 60,
+};
 
 export async function GET() {
   const user = await getAuthenticatedUser();
@@ -25,15 +37,35 @@ export async function PATCH(req: Request) {
   const user = await getAuthenticatedUser();
   if (!user) return errorResponse("Unauthorized", 401);
 
+  const { success: withinLimit } = prefsLimiter.check(user.id);
+  if (!withinLimit) {
+    return errorResponse("Rate limit exceeded. Try again shortly.", 429);
+  }
+
   const body = await req.json();
 
   const updates: Record<string, unknown> = { updatedAt: new Date() };
-  if (body.timezone) updates.timezone = body.timezone;
-  if (body.preferences) {
-    updates.preferences = {
-      ...(user.preferences as object),
-      ...body.preferences,
-    };
+
+  if (body.timezone) {
+    if (typeof body.timezone !== "string" || !isValidTimezone(body.timezone)) {
+      return errorResponse("Invalid timezone", 400);
+    }
+    updates.timezone = body.timezone;
+  }
+
+  if (body.preferences && typeof body.preferences === "object") {
+    const sanitized: Record<string, number> = {};
+    for (const [key, value] of Object.entries(body.preferences)) {
+      if (key in ALLOWED_PREFS && ALLOWED_PREFS[key](value)) {
+        sanitized[key] = value as number;
+      }
+    }
+    if (Object.keys(sanitized).length > 0) {
+      updates.preferences = {
+        ...(user.preferences as object),
+        ...sanitized,
+      };
+    }
   }
 
   const [updated] = await db

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -11,7 +11,6 @@ export const authConfig: NextAuthConfig = {
     Google({
       clientId: process.env.AUTH_GOOGLE_ID,
       clientSecret: process.env.AUTH_GOOGLE_SECRET,
-      allowDangerousEmailAccountLinking: true,
       authorization: {
         params: {
           scope:

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,46 @@
+type RateLimitEntry = { count: number; resetAt: number };
+
+const stores = new Map<string, Map<string, RateLimitEntry>>();
+
+export function rateLimit(opts: {
+  key: string;
+  limit: number;
+  windowMs: number;
+}) {
+  if (!stores.has(opts.key)) {
+    stores.set(opts.key, new Map());
+  }
+  const store = stores.get(opts.key)!;
+
+  return {
+    check(identifier: string): { success: boolean; remaining: number } {
+      const now = Date.now();
+      const entry = store.get(identifier);
+
+      if (!entry || now > entry.resetAt) {
+        store.set(identifier, { count: 1, resetAt: now + opts.windowMs });
+        return { success: true, remaining: opts.limit - 1 };
+      }
+
+      if (entry.count >= opts.limit) {
+        return { success: false, remaining: 0 };
+      }
+
+      entry.count++;
+      return { success: true, remaining: opts.limit - entry.count };
+    },
+  };
+}
+
+// Periodic cleanup of expired entries
+if (typeof globalThis !== "undefined") {
+  const CLEANUP_INTERVAL = 60_000;
+  setInterval(() => {
+    const now = Date.now();
+    for (const store of stores.values()) {
+      for (const [key, entry] of store) {
+        if (now > entry.resetAt) store.delete(key);
+      }
+    }
+  }, CLEANUP_INTERVAL).unref?.();
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,3 +14,13 @@ export function toLocalDateStr(date: Date): string {
 export function isoToLocalDate(iso: string): string {
   return toLocalDateStr(new Date(iso));
 }
+
+/** Check whether a timezone string is recognized by the Intl API */
+export function isValidTimezone(tz: string): boolean {
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- **Remove `allowDangerousEmailAccountLinking`** — eliminates account takeover risk from unverified email linking
- **Add HTTP security headers** — CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy via `next.config.ts`
- **Add in-memory rate limiting** — per-user sliding window on chat (20/min), tasks (30/min), blocks (30/min), preferences (10/min)
- **Validate date inputs** in blocks route — reject unparseable dates, enforce `endTime > startTime`
- **Allowlist preferences** — only known keys with type+range validation accepted; timezone validated via Intl API

## Test plan

- [ ] Sign in with Google — verify auth works after removing `allowDangerousEmailAccountLinking`
- [ ] Check response headers in browser devtools — verify CSP, HSTS, X-Frame-Options present
- [ ] Send 20+ chat messages rapidly — verify 429 response after limit
- [ ] POST `/api/blocks` with invalid dates — verify 400 error
- [ ] PATCH `/api/user/preferences` with unknown keys — verify they are stripped
- [ ] `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)