### PR TITLE
fix: use user timezone for date calculations

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -10,24 +10,27 @@ import { buildSystemPrompt } from "@/lib/chat/planner-prompt";
 import { handleAction, type ActionResult } from "@/lib/chat/action-handler";
 import { dbTaskToTask, dbBlockToTimeBlock } from "@/lib/types";
 import { jsonResponse, errorResponse } from "@/lib/api-helpers";
-import { toLocalDateStr, isValidTimezone } from "@/lib/utils";
+import { toLocalDateStr, toDateStrInTimezone, isValidTimezone } from "@/lib/utils";
 import { extractMemories, getMemoryDigest, saveMemories } from "@/lib/chat/memory";
 import { buildTieredContext } from "@/lib/chat/context-builder";
 import { rateLimit } from "@/lib/rate-limit";
 
 const chatLimiter = rateLimit({ key: "chat", limit: 20, windowMs: 60_000 });
 
-function getWeekRange() {
+function getWeekRange(timezone: string) {
   const now = new Date();
-  const day = now.getDay();
-  const diff = now.getDate() - day + (day === 0 ? -6 : 1);
-  const monday = new Date(now);
+  // Get today's date in the user's timezone, then work from noon to avoid DST issues
+  const todayStr = toDateStrInTimezone(now, timezone);
+  const today = new Date(todayStr + "T12:00:00");
+  const day = today.getDay();
+  const diff = today.getDate() - day + (day === 0 ? -6 : 1);
+  const monday = new Date(today);
   monday.setDate(diff);
   const sunday = new Date(monday);
   sunday.setDate(monday.getDate() + 6);
   return {
-    start: toLocalDateStr(monday),
-    end: toLocalDateStr(sunday),
+    start: toDateStrInTimezone(monday, timezone),
+    end: toDateStrInTimezone(sunday, timezone),
   };
 }
 
@@ -49,8 +52,6 @@ export async function POST(req: Request) {
   if (!withinLimit) {
     return errorResponse("Rate limit exceeded. Try again shortly.", 429);
   }
-  const weekRange = getWeekRange();
-
   // Save user message
   await db.insert(chatMessages).values({
     userId,
@@ -106,6 +107,8 @@ export async function POST(req: Request) {
       .where(eq(users.id, userId))
       .catch(() => null); // best-effort, don't block chat
   }
+
+  const weekRange = getWeekRange(userTimezone);
 
   // Build tiered context for the LLM
   const tieredContext = buildTieredContext({

--- a/src/lib/chat/planner-prompt.ts
+++ b/src/lib/chat/planner-prompt.ts
@@ -1,5 +1,5 @@
 import type { User } from "@/lib/types";
-import { toLocalDateStr } from "@/lib/utils";
+import { toDateStrInTimezone } from "@/lib/utils";
 
 export function buildSimpleSystemPrompt(userName: string): string {
   return `You are Runekeeper, a warm and concise weekly planning assistant.
@@ -28,17 +28,16 @@ export function buildSystemPrompt(context: {
     memoryDigest,
   } = context;
 
+  const tz = user.timezone;
   const now = new Date();
-  const todayStr = toLocalDateStr(now);
+  const todayStr = toDateStrInTimezone(now, tz);
   const todayReadable = now.toLocaleDateString("en-US", {
     weekday: "long",
     year: "numeric",
     month: "long",
     day: "numeric",
+    timeZone: tz,
   });
-
-  const tomorrow = new Date(now);
-  tomorrow.setDate(tomorrow.getDate() + 1);
 
   const dayNames = [
     "Sunday",
@@ -49,11 +48,19 @@ export function buildSystemPrompt(context: {
     "Friday",
     "Saturday",
   ];
+
+  // Build upcoming days using timezone-aware dates
+  const todayLocal = new Date(todayStr + "T12:00:00"); // noon avoids DST edge cases
+  const tomorrowLocal = new Date(todayLocal);
+  tomorrowLocal.setDate(tomorrowLocal.getDate() + 1);
+
   const upcomingDays = Array.from({ length: 7 }, (_, i) => {
-    const d = new Date(now);
-    d.setDate(d.getDate() + i);
-    const label = i === 0 ? "today" : i === 1 ? "tomorrow/tmr" : dayNames[d.getDay()];
-    return `  - ${label}: ${toLocalDateStr(d)} (${dayNames[d.getDay()]})`;
+    const d = new Date(todayLocal);
+    d.setDate(todayLocal.getDate() + i);
+    const dateStr = toDateStrInTimezone(d, tz);
+    const dayName = d.toLocaleDateString("en-US", { weekday: "long", timeZone: tz });
+    const label = i === 0 ? "today" : i === 1 ? "tomorrow/tmr" : dayName;
+    return `  - ${label}: ${dateStr} (${dayName})`;
   }).join("\n");
 
   return `You are Runekeeper, a weekly planning assistant. Your output is a JSON object with "message" (text for the user) and "actions" (array of actions to execute). The schema is enforced — just fill in the fields.
@@ -64,8 +71,8 @@ export function buildSystemPrompt(context: {
 - Reference the "Enchanted Archivist" theme subtly (e.g., "quests" for tasks, "map" for schedule)
 
 ## Current Date & Time Reference
-TODAY IS: ${todayReadable} (${todayStr}, ${dayNames[now.getDay()]})
-TOMORROW IS: ${toLocalDateStr(tomorrow)} (${dayNames[tomorrow.getDay()]})
+TODAY IS: ${todayReadable} (${todayStr})
+TOMORROW IS: ${toDateStrInTimezone(tomorrowLocal, tz)} (${tomorrowLocal.toLocaleDateString("en-US", { weekday: "long", timeZone: tz })})
 
 Date-to-day lookup (use these EXACTLY — do NOT guess day names):
 ${upcomingDays}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,6 +15,11 @@ export function isoToLocalDate(iso: string): string {
   return toLocalDateStr(new Date(iso));
 }
 
+/** Format a Date to YYYY-MM-DD in a specific timezone */
+export function toDateStrInTimezone(date: Date, timezone: string): string {
+  return date.toLocaleDateString("en-CA", { timeZone: timezone });
+}
+
 /** Check whether a timezone string is recognized by the Intl API */
 export function isValidTimezone(tz: string): boolean {
   try {


### PR DESCRIPTION
## Summary
- **Root cause:** `buildSystemPrompt()` and `getWeekRange()` used `new Date()` on the server (UTC), so at 8:49 PM EDT the server saw 00:49 UTC the next day — telling the model it was Tuesday when it was actually Monday
- Added `toDateStrInTimezone()` helper that formats dates in the user's timezone via `Intl`
- All date/day-name calculations in the system prompt and week range now use `user.timezone`

Closes #10

## Test plan
- [ ] Deploy and verify the model reports the correct day/date in chat
- [ ] Test near midnight in user's timezone to confirm no date drift
- [ ] Verify week boundaries (Monday–Sunday) are correct for non-UTC timezones

🤖 Generated with [Claude Code](https://claude.com/claude-code)