### PR TITLE
feat: ink spread transition for Plan Your Week CTA

### DIFF
--- a/src/app/planner/planner-shell.tsx
+++ b/src/app/planner/planner-shell.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { PlannerProvider, usePlanner } from "@/context/planner-context";
-import type { ViewId } from "@/context/planner-context";
+import type { ViewId, TransitionMode } from "@/context/planner-context";
+import { viewInkSpread, viewInstant } from "@/lib/animations";
 import { Sidebar } from "@/components/layout/sidebar";
 import { AppHeader } from "@/components/layout/app-header";
 import { CalendarView } from "@/components/schedule/calendar-view";
@@ -67,8 +68,12 @@ const bottomNavItems: { id: ViewId; label: string; icon: (active: boolean) => Re
   },
 ];
 
+function getViewVariants(mode: TransitionMode) {
+  return mode === "ink-spread" ? viewInkSpread : viewInstant;
+}
+
 function PlannerShell() {
-  const { currentView, setCurrentView } = usePlanner();
+  const { currentView, setCurrentView, transitionMode, setTransitionMode } = usePlanner();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const handleNavigate = (view: ViewId) => {
@@ -124,15 +129,32 @@ function PlannerShell() {
           onOpenMenu={() => setSidebarOpen(true)}
         />
         <div className="flex-1 overflow-hidden min-h-0">
-          {currentView === "home" && <HomeDashboard />}
-          {currentView === "chat" && <ChatContainer />}
-          {currentView === "quest-log" && <InventoryPanel />}
-          {currentView === "calendar" && <CalendarView />}
-          {currentView === "settings" && (
-            <div className="overflow-y-auto archivist-scroll h-full">
-              <SettingsPage />
-            </div>
-          )}
+          <AnimatePresence
+            mode={transitionMode === "ink-spread" ? "wait" : "sync"}
+            initial={false}
+          >
+            <motion.div
+              key={currentView}
+              variants={getViewVariants(transitionMode)}
+              initial="initial"
+              animate="animate"
+              exit="exit"
+              onAnimationComplete={() => {
+                if (transitionMode !== "none") setTransitionMode("none");
+              }}
+              className="h-full"
+            >
+              {currentView === "home" && <HomeDashboard />}
+              {currentView === "chat" && <ChatContainer />}
+              {currentView === "quest-log" && <InventoryPanel />}
+              {currentView === "calendar" && <CalendarView />}
+              {currentView === "settings" && (
+                <div className="overflow-y-auto archivist-scroll h-full">
+                  <SettingsPage />
+                </div>
+              )}
+            </motion.div>
+          </AnimatePresence>
         </div>
       </main>
 

--- a/src/components/home/home-dashboard.tsx
+++ b/src/components/home/home-dashboard.tsx
@@ -7,14 +7,19 @@ import { ScheduledBlocks } from "./scheduled-blocks";
 import { PlanCTA } from "./plan-cta";
 
 export function HomeDashboard() {
-  const { user, setCurrentView } = usePlanner();
+  const { user, setCurrentView, setTransitionMode } = usePlanner();
+
+  const handlePlanCTA = () => {
+    setTransitionMode("ink-spread");
+    setCurrentView("chat");
+  };
 
   return (
     <div className="overflow-y-auto archivist-scroll h-full pb-8">
       <WelcomeSection userName={user.name} />
       <TodayQuests />
       <ScheduledBlocks />
-      <PlanCTA onNavigateToChat={() => setCurrentView("chat")} />
+      <PlanCTA onNavigateToChat={handlePlanCTA} />
     </div>
   );
 }

--- a/src/context/planner-context.tsx
+++ b/src/context/planner-context.tsx
@@ -53,6 +53,7 @@ function getWeekRange(date: Date): WeekRange {
 // ─── Context Types ───────────────────────────────────────────────────────────
 
 export type ViewId = "home" | "chat" | "quest-log" | "calendar" | "settings";
+export type TransitionMode = "none" | "ink-spread";
 
 interface PlannerState {
   user: User;
@@ -62,6 +63,7 @@ interface PlannerState {
   isTyping: boolean;
   isLoading: boolean;
   currentView: ViewId;
+  transitionMode: TransitionMode;
   drawerOpen: boolean;
   weekRange: WeekRange;
 }
@@ -73,6 +75,7 @@ interface PlannerActions {
   updateTask: (taskId: string, updates: Partial<Task>, startTime?: string) => void;
   deleteTask: (taskId: string) => void;
   setCurrentView: (view: ViewId) => void;
+  setTransitionMode: (mode: TransitionMode) => void;
   toggleDrawer: () => void;
   commitProposedBlocks: () => void;
   navigateWeek: (direction: -1 | 1) => void;
@@ -95,6 +98,7 @@ export function PlannerProvider({ children }: { children: ReactNode }) {
   const [isTyping, setIsTyping] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [currentView, setCurrentView] = useState<ViewId>("home");
+  const [transitionMode, setTransitionMode] = useState<TransitionMode>("none");
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [weekRange, setWeekRange] = useState<WeekRange>(
     getWeekRange(new Date())
@@ -413,6 +417,7 @@ export function PlannerProvider({ children }: { children: ReactNode }) {
       isTyping,
       isLoading,
       currentView,
+      transitionMode,
       drawerOpen,
       weekRange,
       sendMessage,
@@ -421,6 +426,7 @@ export function PlannerProvider({ children }: { children: ReactNode }) {
       updateTask,
       deleteTask,
       setCurrentView,
+      setTransitionMode,
       toggleDrawer,
       commitProposedBlocks,
       navigateWeek,
@@ -434,6 +440,7 @@ export function PlannerProvider({ children }: { children: ReactNode }) {
       isTyping,
       isLoading,
       currentView,
+      transitionMode,
       drawerOpen,
       weekRange,
       sendMessage,
@@ -441,6 +448,7 @@ export function PlannerProvider({ children }: { children: ReactNode }) {
       addTask,
       updateTask,
       deleteTask,
+      setTransitionMode,
       toggleDrawer,
       commitProposedBlocks,
       navigateWeek,

--- a/src/lib/animations.ts
+++ b/src/lib/animations.ts
@@ -46,3 +46,23 @@ export const collapseVariants: Variants = {
     transition: { duration: 0.2, ease: "easeIn" },
   },
 };
+
+export const viewInkSpread: Variants = {
+  initial: { opacity: 0, scale: 0.97 },
+  animate: {
+    opacity: 1,
+    scale: 1,
+    transition: { duration: 0.3, ease: "easeOut" },
+  },
+  exit: {
+    opacity: 0,
+    scale: 0.97,
+    transition: { duration: 0.25, ease: "easeIn" },
+  },
+};
+
+export const viewInstant: Variants = {
+  initial: { opacity: 1 },
+  animate: { opacity: 1 },
+  exit: { opacity: 1 },
+};


### PR DESCRIPTION
## Summary
- Adds a smooth ink spread (scale + fade) animation when clicking the "Plan Your Week" CTA button on the home dashboard
- Only the CTA triggers the animation — sidebar and bottom nav transitions remain instant
- Uses framer-motion `AnimatePresence` with a `transitionMode` flag in planner context to conditionally apply the effect

## Test plan
- [ ] Click "Plan Your Week" — home view scales down + fades, chat scales up + fades in (~300ms)
- [ ] Navigate via sidebar/bottom nav — transitions remain instant
- [ ] Navigate back to home, click CTA again — animation replays correctly
- [ ] No layout shift or flash during transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)