### PR TITLE
fix: raise time block duration cap to support full-day events

### DIFF
--- a/src/lib/chat/action-handler.ts
+++ b/src/lib/chat/action-handler.ts
@@ -29,7 +29,7 @@ function sanitizeTaskDef(def: any): {
     priority: VALID_PRIORITIES.includes(def.priority) ? def.priority : "medium",
     estimateMinutes:
       typeof def.estimateMinutes === "number" && def.estimateMinutes > 0
-        ? Math.min(Math.round(def.estimateMinutes), 480)
+        ? Math.min(Math.round(def.estimateMinutes), 1440)
         : 30,
     dueDate: typeof def.dueDate === "string" ? def.dueDate : null,
     startTime: typeof def.startTime === "string" ? def.startTime : null,


### PR DESCRIPTION
## Summary
- The `estimateMinutes` sanitizer in `action-handler.ts` capped task duration at 480 minutes (8 hours), silently truncating longer events
- A 10:30 AM–9:00 PM event (630 min) was clamped to 480 min, causing the calendar entry to end at 6:30 PM instead of 9:00 PM
- Raised the cap to 1440 minutes (24 hours) so single-day events of any length work correctly

## Test plan
- [ ] Create a task spanning >8 hours (e.g., 10:30 AM–9:00 PM) and verify the calendar block covers the full duration
- [ ] Verify shorter tasks (<8 hours) still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)