### PR TITLE
feat: log context sources to Langfuse as RAG-style spans

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -140,7 +140,6 @@ export async function POST(req: Request) {
   });
 
   // Log context sources to Langfuse (RAG-style)
-  const contextSpan = trace.span?.({ name: "context-retrieval" });
   const contextSources = [
     { name: "today-schedule", content: tieredContext.todaySchedule },
     { name: "quest-summary", content: tieredContext.questSummary },
@@ -148,14 +147,22 @@ export async function POST(req: Request) {
     ...(memoryDigest ? [{ name: "memory-digest", content: memoryDigest }] : []),
     { name: "conversation-history", content: `${messages.length} messages` },
   ];
+  const contextSpan = trace.span?.({
+    name: "context-retrieval",
+    input: { sources: contextSources.map((s) => s.name) },
+  });
   for (const source of contextSources) {
     contextSpan?.span?.({
       name: source.name,
-      input: source.content,
+      input: { content: source.content },
       metadata: { tokenEstimate: Math.ceil(source.content.length / 4) },
-    })?.end?.();
+    })?.end?.({
+      output: { content: source.content },
+    });
   }
-  contextSpan?.end?.();
+  contextSpan?.end?.({
+    output: { sourceCount: contextSources.length },
+  });
 
   // Build system prompt
   const systemPrompt = buildSystemPrompt({


### PR DESCRIPTION
## Summary
- Adds a `context-retrieval` parent span to each chat trace in Langfuse
- Logs each context source (today's schedule, quest summary, week overview, memory digest, conversation history) as a child span with content and estimated token count
- Makes it easy to inspect exactly what context the model received for any given response, similar to how RAG systems log retrieved documents

## Test plan
- [ ] Trigger a chat message and verify the Langfuse trace shows a `context-retrieval` span with child spans
- [ ] Verify each child span contains the correct content and token estimate
- [ ] Verify no errors when Langfuse is not configured (noop stubs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)