### PR TITLE
fix: security audit remediations

### DIFF
--- a/src/app/api/calendar/commit/route.ts
+++ b/src/app/api/calendar/commit/route.ts
@@ -3,10 +3,18 @@ import { db } from "@/db";
 import { timeBlocks, planSessions } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 import { jsonResponse, errorResponse } from "@/lib/api-helpers";
+import { rateLimit } from "@/lib/rate-limit";
+
+const commitLimiter = rateLimit({ key: "calendar-commit", limit: 10, windowMs: 60_000 });
 
 export async function POST(req: Request) {
   const session = await auth();
   if (!session?.user?.id) return errorResponse("Unauthorized", 401);
+
+  const { success: withinLimit } = commitLimiter.check(session.user.id);
+  if (!withinLimit) {
+    return errorResponse("Rate limit exceeded. Try again shortly.", 429);
+  }
 
   const body = await req.json();
   const sessionId = body.sessionId;

--- a/src/app/api/integrations/gmail/webhook/route.ts
+++ b/src/app/api/integrations/gmail/webhook/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server";
+import { timingSafeEqual } from "crypto";
 import { db } from "@/db";
 import { users, integrations, accounts } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
@@ -9,10 +10,17 @@ import { syncGmailForUser } from "@/lib/google/gmail-sync";
 
 const log = createLogger("api:integrations:gmail:webhook");
 
+function verifyWebhookToken(token: string | null): boolean {
+  const secret = process.env.GMAIL_WEBHOOK_SECRET;
+  if (!token || !secret) return false;
+  if (token.length !== secret.length) return false;
+  return timingSafeEqual(Buffer.from(token), Buffer.from(secret));
+}
+
 export async function POST(request: NextRequest) {
-  // Verify shared secret
+  // Verify shared secret (timing-safe comparison)
   const token = request.nextUrl.searchParams.get("token");
-  if (!token || token !== process.env.GMAIL_WEBHOOK_SECRET) {
+  if (!verifyWebhookToken(token)) {
     return errorResponse("Forbidden", 403);
   }
 
@@ -40,7 +48,7 @@ export async function POST(request: NextRequest) {
       .limit(1);
 
     if (!user) {
-      log.warn({ emailAddress }, "webhook received for unknown user");
+      log.warn("webhook received for unknown user");
       return jsonResponse({ status: "ok" });
     }
 
@@ -89,7 +97,7 @@ export async function POST(request: NextRequest) {
       "webhook gmail sync completed"
     );
   } catch (err) {
-    log.error({ err, emailAddress }, "webhook processing error");
+    log.error({ err }, "webhook processing error");
   }
 
   // Always return 200 to acknowledge receipt

--- a/src/app/api/plan/generate/route.ts
+++ b/src/app/api/plan/generate/route.ts
@@ -6,13 +6,20 @@ import { schedule } from "@/lib/scheduler";
 import { generateDiff } from "@/lib/scheduler/diff";
 import { dbTaskToTask, dbBlockToTimeBlock } from "@/lib/types";
 import { jsonResponse, errorResponse } from "@/lib/api-helpers";
+import { rateLimit } from "@/lib/rate-limit";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("plan");
+const generateLimiter = rateLimit({ key: "plan-generate", limit: 5, windowMs: 60_000 });
 
 export async function POST(req: Request) {
   const session = await auth();
   if (!session?.user?.id) return errorResponse("Unauthorized", 401);
+
+  const { success: withinLimit } = generateLimiter.check(session.user.id);
+  if (!withinLimit) {
+    return errorResponse("Rate limit exceeded. Try again shortly.", 429);
+  }
 
   const body = await req.json();
   const { start, end } = body;

--- a/src/app/api/plan/undo/route.ts
+++ b/src/app/api/plan/undo/route.ts
@@ -1,10 +1,20 @@
 import { auth } from "@/lib/auth";
 import { undoLastCommit, performUndo, canUndo } from "@/lib/undo";
 import { jsonResponse, errorResponse } from "@/lib/api-helpers";
+import { rateLimit } from "@/lib/rate-limit";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("api:plan:undo");
+const undoLimiter = rateLimit({ key: "plan-undo", limit: 10, windowMs: 60_000 });
 
 export async function POST(req: Request) {
   const session = await auth();
   if (!session?.user?.id) return errorResponse("Unauthorized", 401);
+
+  const { success: withinLimit } = undoLimiter.check(session.user.id);
+  if (!withinLimit) {
+    return errorResponse("Rate limit exceeded. Try again shortly.", 429);
+  }
 
   const accessToken = (session as any).accessToken;
   const body = await req.json();
@@ -32,7 +42,7 @@ export async function POST(req: Request) {
       errors: result.errors,
     });
   } catch (err: any) {
-    console.error("Undo failed:", err);
+    log.error({ err }, "undo failed");
     return errorResponse("Undo failed", 400);
   }
 }

--- a/src/lib/google/calendar.ts
+++ b/src/lib/google/calendar.ts
@@ -1,3 +1,6 @@
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("google:calendar");
 const CALENDAR_API = "https://www.googleapis.com/calendar/v3";
 
 export interface GoogleEvent {
@@ -61,7 +64,7 @@ export async function listEvents(
 
     if (!res.ok) {
       const error = await res.json().catch(() => ({}));
-      console.error(`Calendar API error ${res.status}: ${error.error?.message || res.statusText}`);
+      log.error({ status: res.status, message: error.error?.message || res.statusText }, "Calendar API error");
       throw new Error("Google Calendar request failed");
     }
 


### PR DESCRIPTION
## Summary
- **Timing-safe webhook verification**: Replace `!==` string comparison with `crypto.timingSafeEqual` for Gmail webhook token validation to prevent timing side-channel attacks
- **PII redaction in logs**: Remove email addresses from webhook log output to prevent sensitive data leakage
- **Structured logging**: Replace `console.error` with Pino structured logger in `calendar.ts` and `plan/undo` route
- **Rate limiting on unprotected endpoints**: Add per-user rate limits to `plan/generate` (5/min), `calendar/commit` (10/min), and `plan/undo` (10/min)

## Test plan
- [ ] Verify Gmail webhook still accepts valid tokens and rejects invalid ones
- [ ] Confirm no `console.*` calls remain in `src/` (`grep -r "console\." src/`)
- [ ] Trigger rate limits on new endpoints and verify 429 responses
- [ ] Run `npx tsc --noEmit` — passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)