### PR TITLE
chore: harden env hygiene after PR52 deploy incident

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # ─── Database ─────────────────────────────────────────────────────────────────
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/runekeeper
-# Used by docker-compose.prod.yml for the Postgres container and app DATABASE_URL
+# Used by docker-compose.prod.yml for the Postgres container and app DATABASE_URL.
+# Required in production: deploy.sh runs under `set -u` and aborts if this is unset.
+# Note: changing this only affects a fresh Postgres volume; on an existing volume
+# you must also `ALTER ROLE runekeeper WITH PASSWORD '...'` to match.
 POSTGRES_PASSWORD=postgres
 
 # ─── Token Encryption (32 bytes = 64 hex chars) ──────────────────────────────
@@ -10,6 +13,10 @@ TOKEN_ENCRYPTION_KEY=
 # ─── NextAuth ─────────────────────────────────────────────────────────────────
 # Generate with: openssl rand -base64 32
 AUTH_SECRET=
+# In production set this to the public HTTPS origin (e.g. your Tailscale Funnel
+# URL). A localhost value here breaks OAuth callbacks behind the proxy. Note that
+# docker-compose substitution lets a NEXTAUTH_URL exported in your shell override
+# this file — unset it before deploying, or the wrong value gets baked in.
 NEXTAUTH_URL=http://localhost:3000
 
 # ─── Google OAuth ─────────────────────────────────────────────────────────────
@@ -33,9 +40,11 @@ LOG_LEVEL=debug
 # Daily quest-digest emails. Get an API key at https://resend.com/api-keys
 # Without a key, digest sending is skipped (no crash).
 RESEND_API_KEY=
-# From address. The free tier can send from onboarding@resend.dev to the email
-# you signed up with; set a verified-domain address to send elsewhere.
-# RESEND_FROM=Runekeeper <onboarding@resend.dev>
+# From address. The free tier can send from onboarding@resend.dev ONLY to the
+# email you signed up with (others get a 403). To send to any recipient, verify a
+# domain at resend.com/domains and use an address on it (a dedicated sending
+# subdomain like send.example.com is recommended).
+# RESEND_FROM=Runekeeper <digest@send.example.com>
 # Global kill-switch for the digest scheduler (default: enabled)
 # EMAIL_NOTIFICATIONS_ENABLED=true
 

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 .env*.local
 .env
 .env.production
+.env*.bak*
 
 # typescript
 *.tsbuildinfo


### PR DESCRIPTION
## Background
PR #52's deploy failed and surfaced several env/config traps. This captures the durable repo-level fixes (the runtime fixes were applied to the server's `.env.production`, DB role password, and the `digest_sent_log` migration).

## Changes
- **`.gitignore`**: add `.env*.bak*` so a backup of `.env.production` (secrets) can never be accidentally committed. We created such backups during incident response.
- **`.env.example`** doc clarifications for the three vars that caused the outage:
  - `POSTGRES_PASSWORD` — note it's **required** (`deploy.sh` runs `set -u` and aborts if unset), plus the existing-volume `ALTER ROLE` caveat (Postgres only honors `POSTGRES_PASSWORD` on a fresh volume).
  - `NEXTAUTH_URL` — must be the public HTTPS origin in prod; a `localhost` value breaks OAuth behind the Funnel. Also flags that a shell-exported `NEXTAUTH_URL` overrides `--env-file` in docker-compose (the actual root cause of the "Configuration" error).
  - `RESEND_FROM` — sandbox sender 403s to non-owner recipients; needs a verified domain.

## Not included (intentionally)
Runtime state on the server (`.env.production` values, DB password, applied migration) — those are deployment state, not version-controlled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)