### PR TITLE
fix(deploy): read POSTGRES_PASSWORD without sourcing the env file

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -19,9 +19,11 @@ until docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" exec db pg_isread
 done
 
 echo "==> Applying database schema (drizzle-kit push)..."
-set -a
-source "$ENV_FILE"
-set +a
+# Read ONLY the password from the env file — do not `source` it. It's a Docker
+# env file, not a shell script: values like RESEND_FROM="Runekeeper <a@b.com>"
+# contain shell metacharacters (< >) that make `source` fail with a syntax error.
+POSTGRES_PASSWORD="$(grep -E '^POSTGRES_PASSWORD=' "$ENV_FILE" | head -1 | cut -d= -f2- | sed -E 's/^"(.*)"$/\1/')"
+: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD not found in $ENV_FILE}"
 export DATABASE_URL="postgresql://runekeeper:${POSTGRES_PASSWORD}@localhost:5432/runekeeper"
 npx drizzle-kit push
 


### PR DESCRIPTION
## Problem
The deploy triggered by merging #53 failed:

```
==> Applying database schema (drizzle-kit push)...
.env.production: line 35: syntax error near unexpected token `newline'
```

`deploy.sh` ran `source .env.production` to read `POSTGRES_PASSWORD`. But `.env.production` is a **Docker env file, not a shell script**. After we added a Resend sender, line 35 is:

```
RESEND_FROM="Runekeeper <digest@send.qamil-mirza.com>"
```

The `<` / `>` are shell **redirection** operators, so `source` aborts. Docker Compose's env-file parser doesn't interpret shell, which is why the app got the correct value but `source` choked.

## Fix
Read **only** `POSTGRES_PASSWORD` with `grep`/`cut` (stripping optional surrounding quotes) instead of sourcing the whole file. No more shell interpretation of unrelated values.

Bonus: a `: "${POSTGRES_PASSWORD:?...}"` guard now fails with an actionable message instead of the cryptic `unbound variable` that caused the original PR #52 deploy failure.

## Verification (run on the prod host)
- `bash -n deploy.sh` — syntax OK
- Extraction yields the correct 8-char password (quotes stripped)
- `npx drizzle-kit push` with the extracted password connects and reports `Changes applied` (schema already in sync)

Note: the server's `.env.production` line was also quoted so the current deploy is already unblocked; this PR is the durable repo-level fix so the failure can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)