### PR TITLE
feat(notifications): Goggins overdue-quest phone calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,29 @@ RESEND_API_KEY=
 # Global kill-switch for the digest scheduler (default: enabled)
 # EMAIL_NOTIFICATIONS_ENABLED=true
 
+# ─── Goggins Overdue-Quest Calls (Twilio + ElevenLabs) ──────────────────────
+# When a quest is past its due date and still not done, place a phone call in a
+# generic intense voice asking why. Personal use; all switches default OFF.
+# Frontend build flag — show the Goggins settings UI at all. Default hidden.
+# NEXT_PUBLIC_GOGGINS_CALLS_ENABLED=false
+# Backend kill-switch for the call scheduler. Default OFF (opt-in).
+# PHONE_NOTIFICATIONS_ENABLED=false
+# Twilio. The free trial can call YOUR OWN verified number (it prepends a short
+# "trial account" preamble); the trial number/credit cover personal volume.
+# Without these the call scheduler no-ops (no crash).
+# TWILIO_ACCOUNT_SID=
+# TWILIO_AUTH_TOKEN=
+# TWILIO_FROM_NUMBER=+15550000000
+# ElevenLabs TTS (free tier ~10 min/month). Use a generic intense LIBRARY voice
+# id — do NOT clone a real person (violates ElevenLabs' terms).
+# ELEVENLABS_API_KEY=
+# ELEVENLABS_VOICE_ID=
+# Optional model override (default: eleven_turbo_v2_5)
+# ELEVENLABS_MODEL=eleven_turbo_v2_5
+# NOTE: NEXTAUTH_URL (above) must be the public HTTPS origin — Twilio fetches the
+# audio from {NEXTAUTH_URL}/api/notifications/goggins/audio, so a localhost value
+# won't work for real calls (use the prod/Funnel URL or a tunnel).
+
 # ─── Gmail Integration (Pub/Sub) ───────────────────────────────────────────
 # Shared secret for verifying Pub/Sub webhook requests
 # GMAIL_WEBHOOK_SECRET=

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ WORKDIR /app
 ENV NODE_ENV=production
 ARG NEXT_PUBLIC_WS_PORT=3001
 ENV NEXT_PUBLIC_WS_PORT=$NEXT_PUBLIC_WS_PORT
+# NEXT_PUBLIC_* vars are inlined at build time, so the Goggins UI flag must be
+# passed as a build arg (not just a runtime env) to show the settings section.
+ARG NEXT_PUBLIC_GOGGINS_CALLS_ENABLED=false
+ENV NEXT_PUBLIC_GOGGINS_CALLS_ENABLED=$NEXT_PUBLIC_GOGGINS_CALLS_ENABLED
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,7 @@ services:
       dockerfile: Dockerfile
       args:
         NEXT_PUBLIC_WS_PORT: "8443"
+        NEXT_PUBLIC_GOGGINS_CALLS_ENABLED: "${NEXT_PUBLIC_GOGGINS_CALLS_ENABLED:-false}"
     restart: unless-stopped
     ports:
       - "127.0.0.1:3000:3000"
@@ -46,6 +47,13 @@ services:
       RESEND_API_KEY: ${RESEND_API_KEY:-}
       RESEND_FROM: ${RESEND_FROM:-Runekeeper <onboarding@resend.dev>}
       EMAIL_NOTIFICATIONS_ENABLED: ${EMAIL_NOTIFICATIONS_ENABLED:-true}
+      PHONE_NOTIFICATIONS_ENABLED: ${PHONE_NOTIFICATIONS_ENABLED:-false}
+      TWILIO_ACCOUNT_SID: ${TWILIO_ACCOUNT_SID:-}
+      TWILIO_AUTH_TOKEN: ${TWILIO_AUTH_TOKEN:-}
+      TWILIO_FROM_NUMBER: ${TWILIO_FROM_NUMBER:-}
+      ELEVENLABS_API_KEY: ${ELEVENLABS_API_KEY:-}
+      ELEVENLABS_VOICE_ID: ${ELEVENLABS_VOICE_ID:-}
+      ELEVENLABS_MODEL: ${ELEVENLABS_MODEL:-eleven_turbo_v2_5}
     depends_on:
       db:
         condition: service_healthy

--- a/drizzle/0004_daffy_the_initiative.sql
+++ b/drizzle/0004_daffy_the_initiative.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "goggins_call_sent_log" jsonb DEFAULT '{}'::jsonb;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1066 @@
+{
+  "id": "e3a2f95f-2d3b-4120-be22-5c9bafeffb32",
+  "prevId": "d498edb7-528a-47c2-bdad-2ccd81e5b9a9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_memories": {
+      "name": "chat_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_memories_user_id_users_id_fk": {
+          "name": "chat_memories_user_id_users_id_fk",
+          "tableFrom": "chat_memories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_session_id": {
+          "name": "plan_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_messages_plan_session_id_plan_sessions_id_fk": {
+          "name": "chat_messages_plan_session_id_plan_sessions_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "plan_sessions",
+          "columnsFrom": [
+            "plan_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_messages_user_id_users_id_fk": {
+          "name": "chat_messages_user_id_users_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "gmail_history_id": {
+          "name": "gmail_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watch_expiration": {
+          "name": "watch_expiration",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integrations_user_provider_idx": {
+          "name": "integrations_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integrations_user_id_users_id_fk": {
+          "name": "integrations_user_id_users_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_sessions": {
+      "name": "plan_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_end": {
+          "name": "week_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'drafting'"
+        },
+        "diff_snapshot": {
+          "name": "diff_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "undo_deadline": {
+          "name": "undo_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_state": {
+          "name": "chat_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plan_sessions_user_id_users_id_fk": {
+          "name": "plan_sessions_user_id_users_id_fk",
+          "tableFrom": "plan_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.processed_emails": {
+      "name": "processed_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_message_id": {
+          "name": "gmail_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_thread_id": {
+          "name": "gmail_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_email": {
+          "name": "sender_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "processed_emails_user_msg_idx": {
+          "name": "processed_emails_user_msg_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "processed_emails_user_id_users_id_fk": {
+          "name": "processed_emails_user_id_users_id_fk",
+          "tableFrom": "processed_emails",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "processed_emails_integration_id_integrations_id_fk": {
+          "name": "processed_emails_integration_id_integrations_id_fk",
+          "tableFrom": "processed_emails",
+          "tableTo": "integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "processed_emails_task_id_tasks_id_fk": {
+          "name": "processed_emails_task_id_tasks_id_fk",
+          "tableFrom": "processed_emails",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "estimate_minutes": {
+          "name": "estimate_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unscheduled'"
+        },
+        "google_task_id": {
+          "name": "google_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_tasklist_id": {
+          "name": "google_tasklist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canvas_assignment_id": {
+          "name": "canvas_assignment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gradescope_assignment_id": {
+          "name": "gradescope_assignment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_user_id_users_id_fk": {
+          "name": "tasks_user_id_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_blocks": {
+      "name": "time_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_type": {
+          "name": "block_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'focus'"
+        },
+        "committed": {
+          "name": "committed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'runekeeper'"
+        },
+        "google_event_id": {
+          "name": "google_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_calendar_id": {
+          "name": "google_calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_etag": {
+          "name": "google_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "time_blocks_user_id_users_id_fk": {
+          "name": "time_blocks_user_id_users_id_fk",
+          "tableFrom": "time_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_blocks_task_id_tasks_id_fk": {
+          "name": "time_blocks_task_id_tasks_id_fk",
+          "tableFrom": "time_blocks",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"workingHoursStart\":9,\"workingHoursEnd\":18,\"lunchDurationMinutes\":30,\"maxBlockMinutes\":120,\"meetingBuffer\":10}'::jsonb"
+        },
+        "digest_sent_log": {
+          "name": "digest_sent_log",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "goggins_call_sent_log": {
+          "name": "goggins_call_sent_log",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "sync_token": {
+          "name": "sync_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_google_id_unique": {
+          "name": "users_google_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "google_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1782323923458,
       "tag": "0003_watery_psylocke",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1782429561130,
+      "tag": "0004_daffy_the_initiative",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "^19.1.0",
         "resend": "^6.14.0",
         "tailwind-merge": "^3.3.0",
+        "twilio": "^6.0.2",
         "ws": "^8.20.0"
       },
       "devDependencies": {
@@ -2008,6 +2009,24 @@
         "@types/node": "*"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -2017,11 +2036,29 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -2029,6 +2066,35 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001781",
@@ -2114,6 +2180,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -2157,6 +2235,38 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-libc": {
@@ -2849,6 +2959,29 @@
         }
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
@@ -2896,6 +3029,51 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -2960,6 +3138,42 @@
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/framer-motion": {
       "version": "12.38.0",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
@@ -3002,6 +3216,52 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.7",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
@@ -3015,12 +3275,63 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/help-me": {
       "version": "5.0.0",
@@ -3058,6 +3369,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/iconv-lite": {
@@ -3099,6 +3423,49 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/langfuse": {
@@ -3386,6 +3753,48 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3394,6 +3803,36 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimist": {
@@ -3419,6 +3858,12 @@
       "version": "12.36.0",
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
       "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/mustache": {
@@ -3603,6 +4048,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/on-exit-leak-free": {
@@ -3939,6 +4396,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -3948,6 +4414,22 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/quick-format-unescaped": {
@@ -4017,6 +4499,26 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -4037,6 +4539,13 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/scmp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.1.0.tgz",
+      "integrity": "sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q==",
+      "deprecated": "Just use Node.js's crypto.timingSafeEqual()",
+      "license": "BSD-3-Clause"
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
@@ -4060,7 +4569,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4111,6 +4619,78 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/sonic-boom": {
@@ -4276,6 +4856,24 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/twilio": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-6.0.2.tgz",
+      "integrity": "sha512-RN3TZxUtxLz2HBZVt62+LdZxQbrMVgYKtuzLgwmO7nqKvR+gQS5mCackD9hf4Y7MmoK/bX7tCm7kaJC8kC8zFA==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.13.5",
+        "dayjs": "^1.11.9",
+        "https-proxy-agent": "^5.0.0",
+        "jsonwebtoken": "^9.0.3",
+        "qs": "^6.14.1",
+        "scmp": "^2.1.0",
+        "xmlbuilder": "^13.0.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -4354,6 +4952,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
+      "integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^19.1.0",
     "resend": "^6.14.0",
     "tailwind-merge": "^3.3.0",
+    "twilio": "^6.0.2",
     "ws": "^8.20.0"
   },
   "devDependencies": {

--- a/server.ts
+++ b/server.ts
@@ -23,6 +23,7 @@ import { dbTaskToTask, dbBlockToTimeBlock } from "./src/lib/types";
 import { VoiceSessionLogger } from "./src/lib/voice/session-logger";
 import { setRegistry } from "./src/lib/voice/omi-bridge";
 import { startDigestScheduler } from "./src/lib/notifications/scheduler";
+import { startGogginsScheduler } from "./src/lib/notifications/goggins-scheduler";
 
 // ─── Registries (used by OMI webhook via omi-bridge) ───────────────────────
 export const activeVoiceSessions = new Map<
@@ -121,6 +122,9 @@ app.prepare().then(() => {
 
   // Daily quest-digest email reminders (in-process scheduler)
   startDigestScheduler();
+
+  // Goggins overdue-quest phone calls (in-process scheduler)
+  startGogginsScheduler();
 });
 
 async function handleVoiceSession(

--- a/src/app/api/notifications/goggins/audio/route.ts
+++ b/src/app/api/notifications/goggins/audio/route.ts
@@ -1,0 +1,23 @@
+import { getAudio } from "@/lib/notifications/audio-cache";
+
+/**
+ * Serves a freshly-synthesized call MP3 by token. Twilio fetches this URL while
+ * connecting the call, so it must be publicly reachable (the middleware allows
+ * it through unauthenticated). Security is the unguessable token + short TTL.
+ */
+export async function GET(req: Request) {
+  const token = new URL(req.url).searchParams.get("token");
+  if (!token) return new Response("Missing token", { status: 400 });
+
+  const audio = getAudio(token);
+  if (!audio) return new Response("Not found", { status: 404 });
+
+  return new Response(new Uint8Array(audio), {
+    status: 200,
+    headers: {
+      "Content-Type": "audio/mpeg",
+      "Content-Length": String(audio.length),
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/src/app/api/notifications/goggins/test/route.ts
+++ b/src/app/api/notifications/goggins/test/route.ts
@@ -1,0 +1,52 @@
+import {
+  getAuthenticatedUser,
+  jsonResponse,
+  errorResponse,
+} from "@/lib/api-helpers";
+import { placeGogginsCall } from "@/lib/notifications/goggins-scheduler";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("goggins-test");
+
+const REASON_MESSAGE: Record<string, string> = {
+  no_overdue_quests: "No overdue quests — nothing to call about.",
+  not_configured: "No phone number set. Add one in notification settings first.",
+  no_base_url: "NEXTAUTH_URL is not set — Twilio can't fetch the audio.",
+  tts_unavailable: "Voice not generated (ELEVENLABS_API_KEY/VOICE_ID not configured).",
+  phone_unavailable: "Call not placed (Twilio not configured).",
+};
+
+/**
+ * Places the current user's Goggins overdue-quest call immediately, ignoring
+ * the daily time gate. Mirrors the digest test endpoint — used to verify the
+ * call pipeline end-to-end without waiting for the configured call time.
+ */
+export async function POST() {
+  const user = await getAuthenticatedUser();
+  if (!user) return errorResponse("Unauthorized", 401);
+
+  try {
+    const result = await placeGogginsCall({
+      id: user.id,
+      timezone: user.timezone,
+      phoneNumber: user.preferences?.gogginsPhoneNumber,
+    });
+
+    if (result.called) {
+      log.info({ userId: user.id }, "test goggins call placed");
+      return jsonResponse({
+        called: true,
+        message: `Calling ${user.preferences?.gogginsPhoneNumber}…`,
+      });
+    }
+
+    return jsonResponse({
+      called: false,
+      reason: result.reason,
+      message: REASON_MESSAGE[result.reason ?? ""] ?? "Call not placed.",
+    });
+  } catch (err) {
+    log.error({ userId: user.id, err }, "test goggins call failed");
+    return errorResponse("Failed to place call", 500);
+  }
+}

--- a/src/app/api/user/preferences/route.ts
+++ b/src/app/api/user/preferences/route.ts
@@ -50,6 +50,39 @@ export async function PATCH(req: Request) {
     updates.digestTimes = [...new Set(times as string[])].sort();
   }
 
+  // Validate Goggins overdue-call fields when present.
+  if ("gogginsCallEnabled" in updates && typeof updates.gogginsCallEnabled !== "boolean") {
+    return errorResponse("gogginsCallEnabled must be a boolean", 400);
+  }
+  if ("gogginsCallTimes" in updates) {
+    const times = updates.gogginsCallTimes;
+    const isValid =
+      Array.isArray(times) &&
+      times.length <= 12 &&
+      times.every((t: unknown) => typeof t === "string" && /^([01]\d|2[0-3]):[0-5]\d$/.test(t));
+    if (!isValid) {
+      return errorResponse(
+        'gogginsCallTimes must be an array (max 12) of "HH:MM" 24-hour strings',
+        400
+      );
+    }
+    updates.gogginsCallTimes = [...new Set(times as string[])].sort();
+  }
+  if ("gogginsPhoneNumber" in updates) {
+    const phone = updates.gogginsPhoneNumber;
+    const isValid =
+      phone === null ||
+      phone === "" ||
+      (typeof phone === "string" && /^\+?[1-9]\d{6,14}$/.test(phone.replace(/[\s-()]/g, "")));
+    if (!isValid) {
+      return errorResponse("gogginsPhoneNumber must be a valid phone number", 400);
+    }
+    // Normalize to a digits-and-leading-plus form for Twilio (E.164-ish).
+    if (typeof phone === "string" && phone !== "") {
+      updates.gogginsPhoneNumber = phone.replace(/[\s-()]/g, "");
+    }
+  }
+
   const [updated] = await db
     .update(users)
     .set({

--- a/src/components/profile/notification-settings.tsx
+++ b/src/components/profile/notification-settings.tsx
@@ -1,42 +1,96 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { TimeSlotEditor } from "@/components/profile/time-slot-editor";
 import {
   fetchUserPreferences,
   updateUserPreferences,
+  sendGogginsTestCall,
 } from "@/lib/api-client";
 
-const PRESETS: { label: string; time: string }[] = [
-  { label: "Morning", time: "08:00" },
-  { label: "Midday", time: "12:00" },
-  { label: "Evening", time: "18:00" },
-  { label: "Night", time: "21:00" },
-];
+// Build-time flag: hide the entire Goggins section unless explicitly enabled.
+const SHOW_GOGGINS = process.env.NEXT_PUBLIC_GOGGINS_CALLS_ENABLED === "true";
 
 function sortUnique(times: string[]): string[] {
   return [...new Set(times.filter(Boolean))].sort();
 }
 
-/** Pick a starting time for a new row that isn't already in the list. */
-function nextDefaultTime(existing: string[]): string {
-  const candidates = ["09:00", "08:00", "12:00", "18:00", "21:00", "15:00", "07:00", "22:00"];
-  return candidates.find((c) => !existing.includes(c)) ?? "09:00";
+/** Shared toggle switch — same markup for every on/off control here. */
+function Toggle({
+  checked,
+  onChange,
+  label,
+  disabled,
+}: {
+  checked: boolean;
+  onChange: () => void;
+  label: string;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={onChange}
+      disabled={disabled}
+      className={cn(
+        "relative inline-flex h-6 w-11 shrink-0 items-center rounded-full border-0 p-0.5 transition-colors duration-200 disabled:opacity-50",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-tertiary focus-visible:ring-offset-2 focus-visible:ring-offset-surface-bright",
+        checked ? "bg-tertiary" : "bg-[rgba(212,168,96,0.25)]"
+      )}
+    >
+      <span
+        className={cn(
+          "h-5 w-5 rounded-full bg-on-surface transition-transform duration-200",
+          checked ? "translate-x-5" : "translate-x-0"
+        )}
+      />
+    </button>
+  );
 }
 
-/** Turn an IANA zone id into something readable, e.g. America/New_York → America/New York. */
-function prettyZone(tz: string): string {
-  return tz.replace(/_/g, " ");
+/** Build add/update/remove handlers for a "HH:MM" list bound to a state setter. */
+function timeHandlers(
+  setTimes: Dispatch<SetStateAction<string[]>>,
+  markDirty: () => void
+) {
+  return {
+    onUpdate: (index: number, value: string) => {
+      setTimes((prev) => prev.map((t, i) => (i === index ? value : t)));
+      markDirty();
+    },
+    onRemove: (index: number) => {
+      setTimes((prev) => prev.filter((_, i) => i !== index));
+      markDirty();
+    },
+    onAdd: (value: string) => {
+      setTimes((prev) => (prev.includes(value) ? prev : [...prev, value]));
+      markDirty();
+    },
+  };
 }
 
 export function NotificationSettings({ timezone }: { timezone: string }) {
   const [loading, setLoading] = useState(true);
   const [enabled, setEnabled] = useState(true);
   const [times, setTimes] = useState<string[]>(["08:00"]);
+
+  // Goggins overdue-quest calls
+  const [gogginsEnabled, setGogginsEnabled] = useState(false);
+  const [gogginsPhone, setGogginsPhone] = useState("");
+  const [gogginsTimes, setGogginsTimes] = useState<string[]>(["18:00"]);
+
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
+  const [testing, setTesting] = useState(false);
+  const [testFeedback, setTestFeedback] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -49,6 +103,13 @@ export function NotificationSettings({ timezone }: { timezone: string }) {
           Array.isArray(prefs.digestTimes) && prefs.digestTimes.length > 0
             ? sortUnique(prefs.digestTimes)
             : ["08:00"]
+        );
+        setGogginsEnabled(prefs.gogginsCallEnabled === true);
+        setGogginsPhone(prefs.gogginsPhoneNumber ?? "");
+        setGogginsTimes(
+          Array.isArray(prefs.gogginsCallTimes) && prefs.gogginsCallTimes.length > 0
+            ? sortUnique(prefs.gogginsCallTimes)
+            : ["18:00"]
         );
       })
       .catch(() => setFeedback("Couldn't load your settings. Reload to try again."))
@@ -63,29 +124,38 @@ export function NotificationSettings({ timezone }: { timezone: string }) {
     setFeedback(null);
   };
 
-  const updateTime = (index: number, value: string) => {
-    setTimes((prev) => prev.map((t, i) => (i === index ? value : t)));
-    markDirty();
-  };
+  const digestTimeHandlers = timeHandlers(setTimes, markDirty);
+  const gogginsTimeHandlers = timeHandlers(setGogginsTimes, markDirty);
 
-  const removeTime = (index: number) => {
-    setTimes((prev) => prev.filter((_, i) => i !== index));
-    markDirty();
-  };
-
-  const addTime = (value: string) => {
-    setTimes((prev) => (prev.includes(value) ? prev : [...prev, value]));
-    markDirty();
+  const handleTestCall = async () => {
+    setTesting(true);
+    setTestFeedback(null);
+    try {
+      const res = await sendGogginsTestCall();
+      setTestFeedback(res?.message ?? (res?.called ? "Calling…" : "No call placed."));
+    } catch {
+      setTestFeedback("Test failed. Check the server logs and your config.");
+    } finally {
+      setTesting(false);
+    }
   };
 
   const handleSave = async () => {
     setSaving(true);
     setFeedback(null);
     const cleaned = sortUnique(times);
+    const cleanedGoggins = sortUnique(gogginsTimes);
     try {
       const res = await updateUserPreferences({
         digestEnabled: enabled,
         digestTimes: cleaned,
+        ...(SHOW_GOGGINS
+          ? {
+              gogginsCallEnabled: gogginsEnabled,
+              gogginsPhoneNumber: gogginsPhone.trim() || null,
+              gogginsCallTimes: cleanedGoggins,
+            }
+          : {}),
       });
       const saved = res?.preferences ?? {};
       setTimes(
@@ -93,6 +163,16 @@ export function NotificationSettings({ timezone }: { timezone: string }) {
           ? sortUnique(saved.digestTimes)
           : cleaned
       );
+      if (SHOW_GOGGINS) {
+        setGogginsTimes(
+          Array.isArray(saved.gogginsCallTimes) && saved.gogginsCallTimes.length > 0
+            ? sortUnique(saved.gogginsCallTimes)
+            : cleanedGoggins
+        );
+        if (typeof saved.gogginsPhoneNumber === "string") {
+          setGogginsPhone(saved.gogginsPhoneNumber);
+        }
+      }
       setDirty(false);
       setFeedback("Saved.");
     } catch {
@@ -119,29 +199,15 @@ export function NotificationSettings({ timezone }: { timezone: string }) {
               A summary of your open quests, emailed at the times you choose.
             </p>
           </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={enabled}
-            aria-label="Email the quest digest"
-            onClick={() => {
+          <Toggle
+            checked={enabled}
+            onChange={() => {
               setEnabled((v) => !v);
               markDirty();
             }}
+            label="Email the quest digest"
             disabled={loading}
-            className={cn(
-              "relative inline-flex h-6 w-11 shrink-0 items-center rounded-full border-0 p-0.5 transition-colors duration-200 disabled:opacity-50",
-              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-tertiary focus-visible:ring-offset-2 focus-visible:ring-offset-surface-bright",
-              enabled ? "bg-tertiary" : "bg-[rgba(212,168,96,0.25)]"
-            )}
-          >
-            <span
-              className={cn(
-                "h-5 w-5 rounded-full bg-on-surface transition-transform duration-200",
-                enabled ? "translate-x-5" : "translate-x-0"
-              )}
-            />
-          </button>
+          />
         </div>
 
         <div className="h-px bg-[rgba(212,168,96,0.15)]" />
@@ -149,97 +215,106 @@ export function NotificationSettings({ timezone }: { timezone: string }) {
         {/* Sending times */}
         <div
           className={cn(
-            "space-y-3 transition-opacity duration-200",
+            "transition-opacity duration-200",
             enabled ? "opacity-100" : "opacity-40 pointer-events-none"
           )}
         >
-          <div className="flex items-baseline justify-between gap-3">
-            <span className="font-label text-label-sm font-medium tracking-wide uppercase text-on-surface-variant">
-              Sending times
-            </span>
-            <span className="font-label text-label-sm text-on-surface-variant truncate">
-              Shown in {prettyZone(timezone)}
-            </span>
-          </div>
+          <TimeSlotEditor
+            label="Sending times"
+            times={times}
+            loading={loading}
+            timezone={timezone}
+            emptyHint="No times yet. Add one below to start sending your digest."
+            ariaPrefix="Send time"
+            {...digestTimeHandlers}
+          />
+        </div>
 
-          {loading ? (
-            <p className="font-body text-body-md text-on-surface-variant">Loading…</p>
-          ) : times.length === 0 ? (
-            <p className="font-body text-body-md text-on-surface-variant">
-              No times yet. Add one below to start sending your digest.
-            </p>
-          ) : (
-            <ul className="space-y-px">
-              {times.map((t, i) => (
-                <li
-                  key={i}
-                  className="flex items-center gap-4 bg-surface-container-low px-4 py-3"
+        {/* Goggins overdue-quest calls (build-flag gated) */}
+        {SHOW_GOGGINS && (
+          <>
+            <div className="h-px bg-[rgba(212,168,96,0.15)]" />
+
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <p className="font-display text-headline-md text-on-surface leading-tight">
+                  Goggins call
+                </p>
+                <p className="font-body text-body-md text-on-surface-variant mt-1">
+                  When a quest is past due and still not done, get a phone call asking
+                  why. Calls the number below at the times you choose.
+                </p>
+              </div>
+              <Toggle
+                checked={gogginsEnabled}
+                onChange={() => {
+                  setGogginsEnabled((v) => !v);
+                  markDirty();
+                }}
+                label="Enable Goggins overdue-quest calls"
+                disabled={loading}
+              />
+            </div>
+
+            <div
+              className={cn(
+                "space-y-5 transition-opacity duration-200",
+                gogginsEnabled ? "opacity-100" : "opacity-40 pointer-events-none"
+              )}
+            >
+              <Input
+                id="goggins-phone"
+                type="tel"
+                label="Phone number"
+                value={gogginsPhone}
+                onChange={(e) => {
+                  setGogginsPhone(e.target.value);
+                  markDirty();
+                }}
+                placeholder="+1 555 123 4567"
+                aria-label="Goggins call phone number"
+                disabled={loading}
+              />
+              <TimeSlotEditor
+                label="Call times"
+                times={gogginsTimes}
+                loading={loading}
+                timezone={timezone}
+                emptyHint="No times yet. Add one below to schedule your calls."
+                ariaPrefix="Call time"
+                {...gogginsTimeHandlers}
+              />
+
+              {/* Test call — exercises the live pipeline against your saved settings */}
+              <div className="flex flex-wrap items-center gap-3 pt-1">
+                <button
+                  type="button"
+                  onClick={handleTestCall}
+                  disabled={loading || testing || dirty}
+                  className={cn(
+                    "border border-[rgba(212,168,96,0.4)] px-4 py-2",
+                    "font-label text-label-sm font-medium tracking-wide uppercase text-on-surface",
+                    "hover:border-tertiary hover:text-tertiary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-tertiary",
+                    "disabled:opacity-40 disabled:pointer-events-none transition-colors"
+                  )}
                 >
-                  <span aria-hidden className="h-2 w-2 shrink-0 rounded-full bg-tertiary" />
-                  <input
-                    type="time"
-                    value={t}
-                    onChange={(e) => updateTime(i, e.target.value)}
-                    aria-label={`Send time ${i + 1}`}
-                    className={cn(
-                      "flex-1 min-w-0 bg-transparent border-0 p-0 rounded-none",
-                      "font-display text-headline-md leading-none text-[#3a2410] [color-scheme:light]",
-                      "focus:outline-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[#a05a10]",
-                      "[&::-webkit-calendar-picker-indicator]:opacity-50 [&::-webkit-calendar-picker-indicator]:cursor-pointer"
-                    )}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => removeTime(i)}
-                    aria-label={`Remove send time ${i + 1}`}
-                    className="font-label text-label-sm font-medium tracking-wide uppercase text-[#6b5030] hover:text-error focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-error transition-colors"
-                  >
-                    Remove
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-
-          {/* Add — exact custom time is the primary action */}
-          {!loading && (
-            <div className="space-y-2.5 pt-1">
-              <button
-                type="button"
-                onClick={() => addTime(nextDefaultTime(times))}
-                className={cn(
-                  "w-full border border-[rgba(212,168,96,0.4)] py-2.5",
-                  "font-label text-label-sm font-medium tracking-wide uppercase text-on-surface",
-                  "hover:border-tertiary hover:text-tertiary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-tertiary transition-colors"
-                )}
-              >
-                + Add a time
-              </button>
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="font-label text-label-sm tracking-wide uppercase text-on-surface-variant">
-                  Quick add
-                </span>
-                {PRESETS.map((p) => (
-                  <button
-                    key={p.time}
-                    type="button"
-                    onClick={() => addTime(p.time)}
-                    disabled={times.includes(p.time)}
-                    className={cn(
-                      "font-label text-label-sm tracking-wide uppercase px-2.5 py-1",
-                      "border border-[rgba(212,168,96,0.25)] text-on-surface-variant",
-                      "hover:text-on-surface hover:border-[rgba(212,168,96,0.5)]",
-                      "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-tertiary",
-                      "disabled:opacity-40 disabled:pointer-events-none transition-colors"
-                    )}
-                  >
-                    {p.label}
-                  </button>
-                ))}
+                  {testing ? "Calling…" : "Send a test call now"}
+                </button>
+                <div role="status" aria-live="polite">
+                  {dirty ? (
+                    <span className="font-body text-body-md text-on-surface-variant">
+                      Save your changes first to test them.
+                    </span>
+                  ) : testFeedback ? (
+                    <span className="font-body text-body-md text-on-surface-variant">
+                      {testFeedback}
+                    </span>
+                  ) : null}
+                </div>
               </div>
             </div>
-          )}
-        </div>
+          </>
+        )}
 
         {/* Save */}
         <div className="flex items-center gap-3 pt-1">

--- a/src/components/profile/time-slot-editor.tsx
+++ b/src/components/profile/time-slot-editor.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+const PRESETS: { label: string; time: string }[] = [
+  { label: "Morning", time: "08:00" },
+  { label: "Midday", time: "12:00" },
+  { label: "Evening", time: "18:00" },
+  { label: "Night", time: "21:00" },
+];
+
+/** Pick a starting time for a new row that isn't already in the list. */
+function nextDefaultTime(existing: string[]): string {
+  const candidates = ["09:00", "08:00", "12:00", "18:00", "21:00", "15:00", "07:00", "22:00"];
+  return candidates.find((c) => !existing.includes(c)) ?? "09:00";
+}
+
+/** Turn an IANA zone id into something readable, e.g. America/New_York → America/New York. */
+function prettyZone(tz: string): string {
+  return tz.replace(/_/g, " ");
+}
+
+export interface TimeSlotEditorProps {
+  /** Heading for the section, e.g. "Sending times" / "Call times". */
+  label: string;
+  /** Configured "HH:MM" times. */
+  times: string[];
+  /** Whether prefs are still loading (shows a loading line). */
+  loading: boolean;
+  /** User timezone, shown next to the heading. */
+  timezone: string;
+  /** Message shown when there are no times yet. */
+  emptyHint: string;
+  /** Prefix for per-row aria-labels, e.g. "Send time" / "Call time". */
+  ariaPrefix: string;
+  onUpdate: (index: number, value: string) => void;
+  onRemove: (index: number) => void;
+  onAdd: (value: string) => void;
+}
+
+/**
+ * Editable list of "HH:MM" times with add/remove + quick-add presets. Shared by
+ * the quest-digest email schedule and the Goggins-call schedule so the two stay
+ * visually and behaviourally identical.
+ */
+export function TimeSlotEditor({
+  label,
+  times,
+  loading,
+  timezone,
+  emptyHint,
+  ariaPrefix,
+  onUpdate,
+  onRemove,
+  onAdd,
+}: TimeSlotEditorProps) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="font-label text-label-sm font-medium tracking-wide uppercase text-on-surface-variant">
+          {label}
+        </span>
+        <span className="font-label text-label-sm text-on-surface-variant truncate">
+          Shown in {prettyZone(timezone)}
+        </span>
+      </div>
+
+      {loading ? (
+        <p className="font-body text-body-md text-on-surface-variant">Loading…</p>
+      ) : times.length === 0 ? (
+        <p className="font-body text-body-md text-on-surface-variant">{emptyHint}</p>
+      ) : (
+        <ul className="space-y-px">
+          {times.map((t, i) => (
+            <li
+              key={i}
+              className="flex items-center gap-4 bg-surface-container-low px-4 py-3"
+            >
+              <span aria-hidden className="h-2 w-2 shrink-0 rounded-full bg-tertiary" />
+              <input
+                type="time"
+                value={t}
+                onChange={(e) => onUpdate(i, e.target.value)}
+                aria-label={`${ariaPrefix} ${i + 1}`}
+                className={cn(
+                  "flex-1 min-w-0 bg-transparent border-0 p-0 rounded-none",
+                  "font-display text-headline-md leading-none text-[#3a2410] [color-scheme:light]",
+                  "focus:outline-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[#a05a10]",
+                  "[&::-webkit-calendar-picker-indicator]:opacity-50 [&::-webkit-calendar-picker-indicator]:cursor-pointer"
+                )}
+              />
+              <button
+                type="button"
+                onClick={() => onRemove(i)}
+                aria-label={`Remove ${ariaPrefix.toLowerCase()} ${i + 1}`}
+                className="font-label text-label-sm font-medium tracking-wide uppercase text-[#6b5030] hover:text-error focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-error transition-colors"
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Add — exact custom time is the primary action */}
+      {!loading && (
+        <div className="space-y-2.5 pt-1">
+          <button
+            type="button"
+            onClick={() => onAdd(nextDefaultTime(times))}
+            className={cn(
+              "w-full border border-[rgba(212,168,96,0.4)] py-2.5",
+              "font-label text-label-sm font-medium tracking-wide uppercase text-on-surface",
+              "hover:border-tertiary hover:text-tertiary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-tertiary transition-colors"
+            )}
+          >
+            + Add a time
+          </button>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-label text-label-sm tracking-wide uppercase text-on-surface-variant">
+              Quick add
+            </span>
+            {PRESETS.map((p) => (
+              <button
+                key={p.time}
+                type="button"
+                onClick={() => onAdd(p.time)}
+                disabled={times.includes(p.time)}
+                className={cn(
+                  "font-label text-label-sm tracking-wide uppercase px-2.5 py-1",
+                  "border border-[rgba(212,168,96,0.25)] text-on-surface-variant",
+                  "hover:text-on-surface hover:border-[rgba(212,168,96,0.5)]",
+                  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-tertiary",
+                  "disabled:opacity-40 disabled:pointer-events-none transition-colors"
+                )}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -30,6 +30,10 @@ export const users = pgTable("users", {
     // Quest-digest email reminders
     digestEnabled?: boolean; // master on/off; default on when undefined
     digestTimes?: string[]; // local send times as "HH:MM" (24h), e.g. ["08:00","12:00","21:00"]
+    // Goggins overdue-quest phone calls (opt-in; off unless explicitly true)
+    gogginsCallEnabled?: boolean; // master on/off; default OFF
+    gogginsCallTimes?: string[]; // local call times as "HH:MM" (24h), default ["18:00"]
+    gogginsPhoneNumber?: string | null; // E.164-ish number to call, e.g. "+15551234567"
   }>().default({
     workingHoursStart: 9,
     workingHoursEnd: 18,
@@ -40,6 +44,8 @@ export const users = pgTable("users", {
   // Per-slot digest dedup: maps "HH:MM" send time -> local date ("YYYY-MM-DD") last sent.
   // Restart-safe; one entry per configured time.
   digestSentLog: jsonb("digest_sent_log").$type<Record<string, string>>().default({}),
+  // Per-slot Goggins-call dedup: maps "HH:MM" call time -> local date ("YYYY-MM-DD") last called.
+  gogginsCallSentLog: jsonb("goggins_call_sent_log").$type<Record<string, string>>().default({}),
   syncToken: text("sync_token"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -135,6 +135,13 @@ export function updateUserPreferences(data: Record<string, unknown>) {
   });
 }
 
+export function sendGogginsTestCall() {
+  return apiFetch<{ called: boolean; reason?: string; message: string }>(
+    "/api/notifications/goggins/test",
+    { method: "POST" }
+  );
+}
+
 // ─── Chat with Ollama ────────────────────────────────────────────────────────
 
 export interface ChatResponse {

--- a/src/lib/notifications/audio-cache.ts
+++ b/src/lib/notifications/audio-cache.ts
@@ -1,0 +1,45 @@
+import { randomBytes } from "crypto";
+
+/**
+ * Tiny in-memory store for freshly-synthesized call audio. A Goggins call works
+ * by handing Twilio a public URL it fetches a few seconds later; rather than
+ * persist the MP3 to disk or DB, we hold it here under an unguessable token with
+ * a short TTL. Single server process + low personal volume make this sufficient
+ * (audio is lost on restart, which only matters mid-call — acceptable).
+ */
+
+const TTL_MS = 10 * 60_000; // 10 minutes — ample for Twilio to fetch the audio
+
+interface Entry {
+  buffer: Buffer;
+  expiresAt: number;
+}
+
+const store = new Map<string, Entry>();
+
+/** Drop expired entries so the map can't grow unbounded. */
+function evictExpired(now: number): void {
+  for (const [token, entry] of store) {
+    if (entry.expiresAt <= now) store.delete(token);
+  }
+}
+
+/** Stores audio and returns an unguessable token to retrieve it. */
+export function putAudio(buffer: Buffer): string {
+  const now = Date.now();
+  evictExpired(now);
+  const token = randomBytes(24).toString("hex");
+  store.set(token, { buffer, expiresAt: now + TTL_MS });
+  return token;
+}
+
+/** Returns the audio for a token, or `null` if missing/expired. */
+export function getAudio(token: string): Buffer | null {
+  const entry = store.get(token);
+  if (!entry) return null;
+  if (entry.expiresAt <= Date.now()) {
+    store.delete(token);
+    return null;
+  }
+  return entry.buffer;
+}

--- a/src/lib/notifications/goggins-scheduler.ts
+++ b/src/lib/notifications/goggins-scheduler.ts
@@ -1,0 +1,155 @@
+import { db } from "@/db";
+import { users, tasks } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { dbTaskToTask } from "@/lib/types";
+import { buildGogginsRant } from "@/lib/notifications/goggins";
+import { synthesizeSpeech } from "@/lib/notifications/tts";
+import { putAudio } from "@/lib/notifications/audio-cache";
+import { placeCall } from "@/lib/notifications/phone";
+import { localNow, resolveSlots } from "@/lib/notifications/time";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("goggins-scheduler");
+
+const TICK_INTERVAL_MS = 60_000; // 1 minute — fire configured times within ~60s
+const DEFAULT_GOGGINS_TIMES = ["18:00"]; // evening, after you've had all day
+
+let started = false;
+
+export interface GogginsCallResult {
+  called: boolean;
+  reason?:
+    | "no_overdue_quests"
+    | "not_configured" // no phone number set
+    | "no_base_url" // NEXTAUTH_URL unset — Twilio can't fetch the audio
+    | "tts_unavailable" // ElevenLabs not configured / failed
+    | "phone_unavailable"; // Twilio not configured
+}
+
+/** Global kill-switch — phone calls are opt-in, so default OFF. */
+function phoneNotificationsEnabled(): boolean {
+  const v = process.env.PHONE_NOTIFICATIONS_ENABLED;
+  return v === "true" || v === "1";
+}
+
+/** Public origin Twilio fetches the audio from; trailing slash trimmed. */
+function publicBaseUrl(): string | null {
+  const raw = process.env.NEXTAUTH_URL;
+  return raw ? raw.replace(/\/+$/, "") : null;
+}
+
+/**
+ * Builds and places the Goggins overdue-quest call for a single user, ignoring
+ * the time gate. Shared by the scheduler tick and the manual test endpoint
+ * (mirrors `buildAndSendDigest`). `placeCall` may throw on a Twilio API error;
+ * callers wrap accordingly so the slot retries on the next tick.
+ */
+export async function placeGogginsCall(user: {
+  id: string;
+  timezone: string;
+  phoneNumber: string | null | undefined;
+}): Promise<GogginsCallResult> {
+  if (!user.phoneNumber) return { called: false, reason: "not_configured" };
+
+  const base = publicBaseUrl();
+  if (!base) return { called: false, reason: "no_base_url" };
+
+  const today = localNow(user.timezone).date;
+  const rows = await db.select().from(tasks).where(eq(tasks.userId, user.id));
+  const overdue = rows
+    .map(dbTaskToTask)
+    .filter((t) => t.status !== "done" && !!t.dueDate && t.dueDate < today);
+
+  const rant = buildGogginsRant(overdue, today);
+  if (!rant) return { called: false, reason: "no_overdue_quests" };
+
+  const audio = await synthesizeSpeech(rant);
+  if (!audio) return { called: false, reason: "tts_unavailable" };
+
+  const token = putAudio(audio);
+  const audioUrl = `${base}/api/notifications/goggins/audio?token=${token}`;
+  const ok = await placeCall({ to: user.phoneNumber, audioUrl });
+
+  return ok ? { called: true } : { called: false, reason: "phone_unavailable" };
+}
+
+/**
+ * One scheduler pass: call every user whose local clock has reached a configured
+ * call slot, who has the feature enabled and a number set, and who has at least
+ * one overdue quest. Dedupes per slot per day via `gogginsCallSentLog`.
+ */
+async function tick(): Promise<void> {
+  if (!phoneNotificationsEnabled()) return;
+
+  const allUsers = await db.select().from(users);
+
+  for (const u of allUsers) {
+    try {
+      const prefs = u.preferences;
+      if (prefs?.gogginsCallEnabled !== true) continue; // opt-in only
+      const phone = prefs?.gogginsPhoneNumber;
+      if (!phone) continue;
+
+      const slots = resolveSlots(prefs?.gogginsCallTimes, DEFAULT_GOGGINS_TIMES);
+      if (slots.length === 0) continue;
+
+      const { date, minutes } = localNow(u.timezone);
+      const sentLog = u.gogginsCallSentLog ?? {};
+
+      // Slots whose time has arrived today but haven't fired yet today.
+      const reached = slots
+        .filter((s) => minutes >= s.mins && sentLog[s.raw] !== date)
+        .sort((a, b) => a.mins - b.mins);
+      if (reached.length === 0) continue;
+
+      // One call per tick — the rant covers all overdue quests regardless of slot.
+      const result = await placeGogginsCall({
+        id: u.id,
+        timezone: u.timezone,
+        phoneNumber: phone,
+      });
+
+      // Persist the dedup log, pruned to currently-configured slots so it can't
+      // grow unbounded. Mark every reached slot as handled today (covers
+      // catch-up after downtime without a burst of calls). A thrown call error
+      // skips this update via the catch below, so the next tick retries.
+      const newLog: Record<string, string> = {};
+      for (const s of slots) if (sentLog[s.raw]) newLog[s.raw] = sentLog[s.raw];
+      for (const s of reached) newLog[s.raw] = date;
+      await db
+        .update(users)
+        .set({ gogginsCallSentLog: newLog })
+        .where(eq(users.id, u.id));
+
+      if (result.called) {
+        log.info(
+          { userId: u.id, slots: reached.map((s) => s.raw) },
+          "[goggins] call placed"
+        );
+      } else {
+        log.debug({ userId: u.id, reason: result.reason }, "[goggins] skipped");
+      }
+    } catch (err) {
+      log.error({ userId: u.id, err }, "[goggins] failed for user");
+    }
+  }
+}
+
+/**
+ * Starts the Goggins overdue-quest call scheduler. Safe to call once at server
+ * boot; repeated calls are ignored.
+ */
+export function startGogginsScheduler(): void {
+  if (started) return;
+  started = true;
+
+  log.info(
+    { intervalMs: TICK_INTERVAL_MS, enabled: phoneNotificationsEnabled() },
+    "goggins scheduler started"
+  );
+
+  void tick().catch((err) => log.error({ err }, "[goggins] initial tick failed"));
+  setInterval(() => {
+    void tick().catch((err) => log.error({ err }, "[goggins] tick failed"));
+  }, TICK_INTERVAL_MS).unref?.();
+}

--- a/src/lib/notifications/goggins.ts
+++ b/src/lib/notifications/goggins.ts
@@ -1,0 +1,62 @@
+import type { Task } from "@/lib/types";
+
+const MAX_NAMED = 3; // read out at most this many quests by name before summarizing
+
+/** Whole days between two "YYYY-MM-DD" dates (b - a), DST-safe (pure UTC math). */
+function daysBetween(a: string, b: string): number {
+  const da = Date.parse(a + "T00:00:00Z");
+  const db = Date.parse(b + "T00:00:00Z");
+  return Math.round((db - da) / 86_400_000);
+}
+
+/** "1 day" / "N days" — for natural read-aloud. */
+function dayPhrase(n: number): string {
+  return n === 1 ? "1 day" : `${n} days`;
+}
+
+/**
+ * Builds the spoken accountability script for a user's overdue quests, in a
+ * generic intense drill-sergeant register (deliberately NOT impersonating any
+ * real person). Returns `null` when there is nothing overdue, mirroring
+ * `buildDigest` — the caller skips the call entirely in that case.
+ *
+ * `today` is the user's local date ("YYYY-MM-DD"); pass it in so this stays a
+ * pure, testable function. `overdue` is expected to already be filtered to
+ * not-done tasks with a `dueDate` strictly before today.
+ */
+export function buildGogginsRant(overdue: Task[], today: string): string | null {
+  if (overdue.length === 0) return null;
+
+  // Most overdue first — the worst offender leads.
+  const sorted = [...overdue].sort((a, b) =>
+    (a.dueDate ?? "").localeCompare(b.dueDate ?? "")
+  );
+
+  const named = sorted.slice(0, MAX_NAMED);
+  const remaining = sorted.length - named.length;
+
+  const callouts = named
+    .map((t) => {
+      const days = t.dueDate ? daysBetween(t.dueDate, today) : 0;
+      return `"${t.title}" was due ${dayPhrase(days)} ago, and it is STILL not done.`;
+    })
+    .join(" ");
+
+  const count = sorted.length === 1 ? "one quest" : `${sorted.length} quests`;
+  const moreClause =
+    remaining > 0
+      ? `And that is not even all of it — you have ${remaining} more sitting there too.`
+      : "";
+
+  return [
+    "Wake up. This is your accountability call.",
+    `You have ${count} past due on your quest log right now.`,
+    callouts,
+    moreClause,
+    "You set these deadlines. Nobody else did.",
+    "Nobody is coming to save you. Stop negotiating with yourself, stop making excuses, and get it DONE.",
+    "No more zero days. Go knock it out. Now.",
+  ]
+    .filter(Boolean)
+    .join(" ");
+}

--- a/src/lib/notifications/phone.ts
+++ b/src/lib/notifications/phone.ts
@@ -1,0 +1,40 @@
+import twilio, { type Twilio } from "twilio";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("phone");
+
+let client: Twilio | null = null;
+
+function getTwilioClient(): Twilio | null {
+  const sid = process.env.TWILIO_ACCOUNT_SID;
+  const token = process.env.TWILIO_AUTH_TOKEN;
+  if (!sid || !token) return null;
+  if (!client) client = twilio(sid, token);
+  return client;
+}
+
+export interface PlaceCallParams {
+  to: string;
+  /** Public URL Twilio will fetch and play (the synthesized MP3). */
+  audioUrl: string;
+}
+
+/**
+ * Places an outbound voice call that plays a single audio clip via inline
+ * TwiML. No-ops (warns, returns false) when Twilio credentials or
+ * `TWILIO_FROM_NUMBER` are unset — same graceful-degradation contract as
+ * `sendEmail`. Returns true when a call was actually initiated.
+ */
+export async function placeCall({ to, audioUrl }: PlaceCallParams): Promise<boolean> {
+  const tw = getTwilioClient();
+  const from = process.env.TWILIO_FROM_NUMBER;
+  if (!tw || !from) {
+    log.warn({ to }, "Twilio not configured (SID/token/from) — skipping call");
+    return false;
+  }
+
+  const twiml = `<Response><Play>${audioUrl}</Play></Response>`;
+  const call = await tw.calls.create({ to, from, twiml });
+  log.info({ to, sid: call.sid }, "call initiated");
+  return true;
+}

--- a/src/lib/notifications/scheduler.ts
+++ b/src/lib/notifications/scheduler.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { dbTaskToTask } from "@/lib/types";
 import { buildDigest } from "@/lib/notifications/digest";
 import { sendEmail } from "@/lib/notifications/email";
+import { localNow, resolveSlots } from "@/lib/notifications/time";
 import { createLogger } from "@/lib/logger";
 
 const log = createLogger("digest-scheduler");
@@ -22,39 +23,6 @@ export interface DigestResult {
 function notificationsEnabled(): boolean {
   const v = process.env.EMAIL_NOTIFICATIONS_ENABLED;
   return v !== "false" && v !== "0";
-}
-
-/** Current local date ("YYYY-MM-DD") and minutes-since-midnight in the given timezone. */
-function localNow(timezone: string): { date: string; minutes: number } {
-  const now = new Date();
-  const date = now.toLocaleDateString("en-CA", { timeZone: timezone });
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone: timezone,
-    hour12: false,
-    hour: "2-digit",
-    minute: "2-digit",
-  }).formatToParts(now);
-  const hh = parseInt(parts.find((p) => p.type === "hour")?.value ?? "0", 10) % 24;
-  const mm = parseInt(parts.find((p) => p.type === "minute")?.value ?? "0", 10);
-  return { date, minutes: hh * 60 + mm };
-}
-
-/** Parse "HH:MM" to minutes-since-midnight, or null if malformed/out of range. */
-function parseSlot(s: string): number | null {
-  const m = /^(\d{1,2}):(\d{2})$/.exec(s.trim());
-  if (!m) return null;
-  const h = Number(m[1]);
-  const min = Number(m[2]);
-  if (h < 0 || h > 23 || min < 0 || min > 59) return null;
-  return h * 60 + min;
-}
-
-/** Resolve a user's configured digest times (valid "HH:MM" slots), defaulting to 08:00. */
-function resolveSlots(times: string[] | undefined): { raw: string; mins: number }[] {
-  const source = times && times.length > 0 ? times : DEFAULT_DIGEST_TIMES;
-  return source
-    .map((raw) => ({ raw, mins: parseSlot(raw) }))
-    .filter((s): s is { raw: string; mins: number } => s.mins !== null);
 }
 
 /**
@@ -94,7 +62,7 @@ async function tick(): Promise<void> {
       const prefs = u.preferences;
       if (prefs?.digestEnabled === false) continue;
 
-      const slots = resolveSlots(prefs?.digestTimes);
+      const slots = resolveSlots(prefs?.digestTimes, DEFAULT_DIGEST_TIMES);
       if (slots.length === 0) continue;
 
       const { date, minutes } = localNow(u.timezone);

--- a/src/lib/notifications/time.ts
+++ b/src/lib/notifications/time.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared time helpers for the notification schedulers (digest email + Goggins
+ * call). Both run a per-minute tick that fires user-configured "HH:MM" slots in
+ * the user's local timezone, so the slot-parsing and local-clock logic lives
+ * here to avoid duplication.
+ */
+
+/** Current local date ("YYYY-MM-DD") and minutes-since-midnight in the given timezone. */
+export function localNow(timezone: string): { date: string; minutes: number } {
+  const now = new Date();
+  const date = now.toLocaleDateString("en-CA", { timeZone: timezone });
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+  }).formatToParts(now);
+  const hh = parseInt(parts.find((p) => p.type === "hour")?.value ?? "0", 10) % 24;
+  const mm = parseInt(parts.find((p) => p.type === "minute")?.value ?? "0", 10);
+  return { date, minutes: hh * 60 + mm };
+}
+
+/** Parse "HH:MM" to minutes-since-midnight, or null if malformed/out of range. */
+export function parseSlot(s: string): number | null {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(s.trim());
+  if (!m) return null;
+  const h = Number(m[1]);
+  const min = Number(m[2]);
+  if (h < 0 || h > 23 || min < 0 || min > 59) return null;
+  return h * 60 + min;
+}
+
+/**
+ * Resolve a list of configured "HH:MM" times into valid slots, falling back to
+ * `defaults` when the list is empty/undefined. Malformed entries are dropped.
+ */
+export function resolveSlots(
+  times: string[] | undefined,
+  defaults: string[]
+): { raw: string; mins: number }[] {
+  const source = times && times.length > 0 ? times : defaults;
+  return source
+    .map((raw) => ({ raw, mins: parseSlot(raw) }))
+    .filter((s): s is { raw: string; mins: number } => s.mins !== null);
+}

--- a/src/lib/notifications/tts.ts
+++ b/src/lib/notifications/tts.ts
@@ -1,0 +1,53 @@
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("tts");
+
+const ELEVENLABS_BASE = "https://api.elevenlabs.io/v1/text-to-speech";
+const DEFAULT_MODEL = "eleven_turbo_v2_5";
+
+/**
+ * Synthesizes speech to an MP3 buffer via ElevenLabs. Returns `null` (with a
+ * warning) when `ELEVENLABS_API_KEY` / `ELEVENLABS_VOICE_ID` are unset or the
+ * request fails, so callers degrade gracefully instead of crashing — the same
+ * "no-op without credentials" contract as `sendEmail`.
+ *
+ * Use a generic intense library voice via `ELEVENLABS_VOICE_ID`. Do NOT clone a
+ * real person's voice (violates ElevenLabs' terms).
+ */
+export async function synthesizeSpeech(text: string): Promise<Buffer | null> {
+  const apiKey = process.env.ELEVENLABS_API_KEY;
+  const voiceId = process.env.ELEVENLABS_VOICE_ID;
+  if (!apiKey || !voiceId) {
+    log.warn("ELEVENLABS_API_KEY/ELEVENLABS_VOICE_ID not set — skipping TTS");
+    return null;
+  }
+
+  const model = process.env.ELEVENLABS_MODEL || DEFAULT_MODEL;
+
+  try {
+    const res = await fetch(`${ELEVENLABS_BASE}/${voiceId}`, {
+      method: "POST",
+      headers: {
+        "xi-api-key": apiKey,
+        "Content-Type": "application/json",
+        Accept: "audio/mpeg",
+      },
+      body: JSON.stringify({
+        text,
+        model_id: model,
+        voice_settings: { stability: 0.4, similarity_boost: 0.75, style: 0.6 },
+      }),
+    });
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      log.error({ status: res.status, detail }, "ElevenLabs TTS request failed");
+      return null;
+    }
+
+    return Buffer.from(await res.arrayBuffer());
+  } catch (err) {
+    log.error({ err }, "ElevenLabs TTS request threw");
+    return null;
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,9 +13,12 @@ export default auth((req) => {
   const isApi = req.nextUrl.pathname.startsWith("/api");
   const isAuthApi = req.nextUrl.pathname.startsWith("/api/auth");
   const isWebhook = req.nextUrl.pathname.endsWith("/webhook");
+  // Twilio fetches this token-guarded audio URL while connecting a Goggins call.
+  const isGogginsAudio =
+    req.nextUrl.pathname === "/api/notifications/goggins/audio";
 
   // Allow auth API routes and external webhooks through (they use their own secret-based auth)
-  if (isAuthApi || isWebhook) return;
+  if (isAuthApi || isWebhook || isGogginsAudio) return;
 
   // Protect planner and non-auth API routes
   if (!isAuth) {


### PR DESCRIPTION
## What

When a quest is **past its due date and still not done**, Runekeeper places a phone call (premade ElevenLabs voice) asking why it isn't done. Built on the existing per-minute digest-scheduler pattern.

## How it works

```
gogginsTick() every 60s
  -> PHONE_NOTIFICATIONS_ENABLED on?
     -> per user: enabled? phone set? slot reached & not sent today?
        -> overdue tasks (status != done && dueDate < today) — none => skip
           -> buildGogginsRant() -> ElevenLabs TTS -> token-keyed audio cache
           -> Twilio call, inline TwiML <Play>{NEXTAUTH_URL}/api/notifications/goggins/audio?token=…</Play>
           -> on success: gogginsCallSentLog[slot] = today
```

`placeGogginsCall()` is shared by the tick and the manual test endpoint (mirrors `buildAndSendDigest`). The audio endpoint is public + token-guarded (allowed through auth middleware) so Twilio can fetch it.

## Three switches (all default OFF)

| Switch | Layer |
|---|---|
| `NEXT_PUBLIC_GOGGINS_CALLS_ENABLED` | frontend build flag — shows/hides the settings UI |
| `PHONE_NOTIFICATIONS_ENABLED` | backend scheduler kill-switch |
| `gogginsCallEnabled` (per-user) | the in-settings toggle |

## Notable

- New modules under `src/lib/notifications/`: `goggins.ts` (pure rant builder), `tts.ts` (ElevenLabs), `audio-cache.ts`, `phone.ts` (Twilio), `goggins-scheduler.ts`. All no-op gracefully without credentials.
- Extracted shared `time.ts` helpers and a reusable `TimeSlotEditor` (used by both digest + Goggins schedules).
- DB: additive `goggins_call_sent_log` column + prefs fields (migration `0004`).
- Settings UI adds a **"Send a test call now"** button to verify end-to-end.

## Deploy notes (prod)

- Set the build arg **`NEXT_PUBLIC_GOGGINS_CALLS_ENABLED=true`** in the deploy env — `NEXT_PUBLIC_*` is inlined at `next build`, so a runtime-only value won't show the UI. Wired into Dockerfile + `docker-compose.prod.yml`.
- Set runtime: `PHONE_NOTIFICATIONS_ENABLED=true`, `TWILIO_ACCOUNT_SID/AUTH_TOKEN/FROM_NUMBER`, `ELEVENLABS_API_KEY`, `ELEVENLABS_VOICE_ID` (use a **premade** voice — free tier blocks library voices via API; default is Adam `pNInz6obpgDQGcFmaJgB`).
- Twilio **trial** can only call a **verified** number and prepends a short "trial account" preamble.
- `NEXTAUTH_URL` must be the public HTTPS origin (it already is in prod) — Twilio fetches the audio from it.

## Testing

Single-user personal feature; verified locally that Twilio creds + verified number work and ElevenLabs synthesizes (premade voice). Full call flow to be validated on prod via the **Send a test call** button after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)