### PR TITLE
fix(notifications): follow the user's actual timezone for digest/calls

### DIFF
--- a/src/app/api/user/preferences/route.ts
+++ b/src/app/api/user/preferences/route.ts
@@ -6,6 +6,7 @@ import {
   jsonResponse,
   errorResponse,
 } from "@/lib/api-helpers";
+import { isValidTimezone } from "@/lib/utils";
 
 export async function GET() {
   const user = await getAuthenticatedUser();
@@ -28,6 +29,19 @@ export async function PATCH(req: Request) {
   const updates = await req.json();
   if (!updates || typeof updates !== "object") {
     return errorResponse("Invalid request body", 400);
+  }
+
+  // Timezone lives on a top-level column, not in the preferences jsonb. Pull it
+  // out so the client can keep it in sync with where the user actually is
+  // (digest/call scheduling and the profile display both read this column).
+  let timezoneUpdate: string | undefined;
+  if ("timezone" in updates) {
+    const tz = updates.timezone;
+    if (typeof tz !== "string" || !isValidTimezone(tz)) {
+      return errorResponse("timezone must be a valid IANA timezone", 400);
+    }
+    timezoneUpdate = tz;
+    delete updates.timezone; // keep it out of the preferences blob
   }
 
   // Validate digest-notification fields when present.
@@ -87,10 +101,11 @@ export async function PATCH(req: Request) {
     .update(users)
     .set({
       preferences: sql`COALESCE(${users.preferences}, '{}'::jsonb) || ${JSON.stringify(updates)}::jsonb`,
+      ...(timezoneUpdate ? { timezone: timezoneUpdate } : {}),
       updatedAt: new Date(),
     })
     .where(eq(users.id, user.id))
     .returning();
 
-  return jsonResponse({ preferences: updated.preferences });
+  return jsonResponse({ preferences: updated.preferences, timezone: updated.timezone });
 }

--- a/src/context/planner-context.tsx
+++ b/src/context/planner-context.tsx
@@ -121,6 +121,15 @@ export function PlannerProvider({ children }: { children: ReactNode }) {
       ]);
 
       if (userPrefs) {
+        // Keep the stored timezone in sync with where the user actually is, so
+        // digest/call scheduling and the profile display follow them as they
+        // travel. Mirrors the chat route's auto-update, but fires on every load
+        // instead of only when a chat message is sent.
+        const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        const timezone = browserTimezone || userPrefs.timezone;
+        if (browserTimezone && browserTimezone !== userPrefs.timezone) {
+          api.updateUserPreferences({ timezone: browserTimezone }).catch(() => null);
+        }
         setUser({
           id: userPrefs.id,
           name: userPrefs.name,
@@ -130,7 +139,7 @@ export function PlannerProvider({ children }: { children: ReactNode }) {
             .join("")
             .toUpperCase()
             .slice(0, 2),
-          timezone: userPrefs.timezone,
+          timezone,
           email: userPrefs.email,
           image: userPrefs.image ?? undefined,
         });


### PR DESCRIPTION
## Problem

A user's timezone is stored in `users.timezone` (DB default `America/New_York`). The notification settings display **and** both schedulers (digest + Goggins, via `localNow(u.timezone)`) read that stored column. The only code that ever corrected it was the chat route — and only when a chat message was sent. So after moving zones (e.g. NY → CA) without chatting, digest emails and Goggins calls kept firing on the old clock, and the profile showed the wrong timezone.

## Fix

Detect the browser's IANA timezone on app load and persist it when it differs — mirroring the chat route's existing auto-update, but firing on every load instead of only on chat.

- `src/context/planner-context.tsx` — on load, detect `Intl.DateTimeFormat().resolvedOptions().timeZone`, `PATCH /api/user/preferences` when it differs, and use it immediately for the in-memory `user.timezone` so the profile label updates right away.
- `src/app/api/user/preferences/route.ts` — `PATCH` now accepts/validates a top-level `timezone` (via `isValidTimezone`) and writes the column, kept out of the `preferences` jsonb blob.

Effect: next app load in California self-corrects the DB to `America/Los_Angeles`, and from then on send/call times fire on Pacific. The `America/New_York` default remains only as the guest/unauthenticated fallback.

## Verification

- `tsc --noEmit` passes.
- This repo has no test framework configured, so verified via typecheck + review (no automated test added — that would be a large unrelated change). Not exercised against a live DB/browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)