### PR TITLE
fix(notifications): back Goggins call audio with the filesystem, not an in-memory Map

### DIFF
--- a/src/app/api/notifications/goggins/audio/route.ts
+++ b/src/app/api/notifications/goggins/audio/route.ts
@@ -9,7 +9,7 @@ export async function GET(req: Request) {
   const token = new URL(req.url).searchParams.get("token");
   if (!token) return new Response("Missing token", { status: 400 });
 
-  const audio = getAudio(token);
+  const audio = await getAudio(token);
   if (!audio) return new Response("Not found", { status: 404 });
 
   return new Response(new Uint8Array(audio), {

--- a/src/lib/notifications/audio-cache.ts
+++ b/src/lib/notifications/audio-cache.ts
@@ -1,45 +1,83 @@
 import { randomBytes } from "crypto";
+import { mkdir, readFile, writeFile, readdir, stat, unlink } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createLogger } from "@/lib/logger";
+
+const log = createLogger("audio-cache");
 
 /**
- * Tiny in-memory store for freshly-synthesized call audio. A Goggins call works
- * by handing Twilio a public URL it fetches a few seconds later; rather than
- * persist the MP3 to disk or DB, we hold it here under an unguessable token with
- * a short TTL. Single server process + low personal volume make this sufficient
- * (audio is lost on restart, which only matters mid-call — acceptable).
+ * Short-lived store for freshly-synthesized Goggins call audio. A call works by
+ * handing Twilio a public URL it fetches a few seconds later; we stash the MP3
+ * here under an unguessable token with a short TTL, then serve it from the audio
+ * route. Security is the unguessable token + short TTL.
+ *
+ * This MUST be backed by the filesystem, not an in-memory Map. The audio is
+ * written either by the scheduler (bundled into server.ts via esbuild) or by the
+ * test API route (Next.js bundle), but it is always *read* by the audio route
+ * (Next.js bundle). Those are separate module instances even though they share a
+ * single process, so a module-level Map populated on one side is invisible on
+ * the other — Twilio then fetches an empty cache, gets a 404/non-audio response,
+ * and plays "an application error has occurred" (Twilio errors 11200 / 12300). A
+ * file on the shared container filesystem is visible to every bundle, so put and
+ * get agree. (For a multi-instance deployment this should move to Postgres/Redis.)
  */
 
 const TTL_MS = 10 * 60_000; // 10 minutes — ample for Twilio to fetch the audio
+const DIR = join(tmpdir(), "runekeeper-goggins-audio");
+const TOKEN_RE = /^[a-f0-9]{48}$/; // 24 random bytes as hex; also blocks path traversal
 
-interface Entry {
-  buffer: Buffer;
-  expiresAt: number;
-}
-
-const store = new Map<string, Entry>();
-
-/** Drop expired entries so the map can't grow unbounded. */
-function evictExpired(now: number): void {
-  for (const [token, entry] of store) {
-    if (entry.expiresAt <= now) store.delete(token);
+/** Delete cached files past their TTL so the directory can't grow unbounded. */
+async function evictExpired(): Promise<void> {
+  let names: string[];
+  try {
+    names = await readdir(DIR);
+  } catch {
+    return; // directory not created yet — nothing to evict
   }
+  const cutoff = Date.now() - TTL_MS;
+  await Promise.all(
+    names.map(async (name) => {
+      try {
+        const path = join(DIR, name);
+        const s = await stat(path);
+        if (s.mtimeMs < cutoff) await unlink(path);
+      } catch {
+        // racing another evict/read — ignore
+      }
+    })
+  );
 }
 
 /** Stores audio and returns an unguessable token to retrieve it. */
-export function putAudio(buffer: Buffer): string {
-  const now = Date.now();
-  evictExpired(now);
+export async function putAudio(buffer: Buffer): Promise<string> {
+  await mkdir(DIR, { recursive: true });
+  await evictExpired();
   const token = randomBytes(24).toString("hex");
-  store.set(token, { buffer, expiresAt: now + TTL_MS });
+  await writeFile(join(DIR, `${token}.mp3`), buffer);
+  log.debug({ token: token.slice(0, 8), bytes: buffer.length, dir: DIR }, "audio stored");
   return token;
 }
 
-/** Returns the audio for a token, or `null` if missing/expired. */
-export function getAudio(token: string): Buffer | null {
-  const entry = store.get(token);
-  if (!entry) return null;
-  if (entry.expiresAt <= Date.now()) {
-    store.delete(token);
+/** Returns the audio for a token, or `null` if missing/expired/malformed. */
+export async function getAudio(token: string): Promise<Buffer | null> {
+  if (!TOKEN_RE.test(token)) {
+    log.warn({ token: token.slice(0, 8) }, "audio fetch with malformed token");
     return null;
   }
-  return entry.buffer;
+  const path = join(DIR, `${token}.mp3`);
+  try {
+    const s = await stat(path);
+    if (s.mtimeMs < Date.now() - TTL_MS) {
+      await unlink(path).catch(() => {});
+      log.debug({ token: token.slice(0, 8) }, "audio expired");
+      return null;
+    }
+    const buf = await readFile(path);
+    log.debug({ token: token.slice(0, 8), bytes: buf.length }, "audio served");
+    return buf;
+  } catch {
+    log.warn({ token: token.slice(0, 8), dir: DIR }, "audio not found");
+    return null;
+  }
 }

--- a/src/lib/notifications/goggins-scheduler.ts
+++ b/src/lib/notifications/goggins-scheduler.ts
@@ -66,7 +66,7 @@ export async function placeGogginsCall(user: {
   const audio = await synthesizeSpeech(rant);
   if (!audio) return { called: false, reason: "tts_unavailable" };
 
-  const token = putAudio(audio);
+  const token = await putAudio(audio);
   const audioUrl = `${base}/api/notifications/goggins/audio?token=${token}`;
   const ok = await placeCall({ to: user.phoneNumber, audioUrl });
 

--- a/src/lib/notifications/phone.ts
+++ b/src/lib/notifications/phone.ts
@@ -35,6 +35,8 @@ export async function placeCall({ to, audioUrl }: PlaceCallParams): Promise<bool
 
   const twiml = `<Response><Play>${audioUrl}</Play></Response>`;
   const call = await tw.calls.create({ to, from, twiml });
-  log.info({ to, sid: call.sid }, "call initiated");
+  // Log the audio URL Twilio will fetch — if a call fails with "an application
+  // error has occurred", this is the URL to check is reachable and serving MP3.
+  log.info({ to, sid: call.sid, audioUrl }, "call initiated");
   return true;
 }


### PR DESCRIPTION
## Symptom

Twilio dials the phone fine, but on answer plays *"We're sorry, an application error has occurred. Goodbye."* Twilio call logs showed two error codes:
- **11200** (HTTP retrieval failure) — scheduled calls
- **12300** (invalid content-type) — test calls

## Root cause

`audio-cache.ts` was a module-level **in-memory `Map`** whose comment assumed a "single server process." But the app is built as **two bundles** running in one process:

- `server.ts` is bundled by **esbuild** (`server-custom.js`) — this is where the **scheduler** runs, so a scheduled call's `putAudio()` writes into *that bundle's* Map.
- The Next.js app is bundled by **webpack**, and each route handler gets its own bundle — so the **test route's** `putAudio()` and the **audio route's** `getAudio()` (the one Twilio fetches) also touch *different* Map instances.

Same process, different module instances → different Maps. Twilio always fetched an empty cache:
- miss → route returns `404 Not found` → Twilio **11200**
- (and the test path's miss returned a non-audio body) → Twilio **12300**

The phone rang because that's Twilio → PSTN; only the `<Play>` audio fetch came up empty.

## Fix

Back the store with the **container filesystem** (`os.tmpdir()/runekeeper-goggins-audio`), which every bundle in the process shares — so `putAudio` and `getAudio` always agree. Same public contract (now `async`):

- `putAudio(buffer): Promise<string>` — write `<token>.mp3`, evict files past TTL.
- `getAudio(token): Promise<Buffer | null>` — hex-only token guard (blocks path traversal), TTL check, read back.
- Updated the two callers to `await`; the audio route still serves `audio/mpeg`.

Also added the logging that was missing: the resolved **audio URL** on call placement (`phone.ts`) and **every audio-route hit** (token, found?, bytes) — so this failure mode is visible in `docker logs` next time.

> Single-container deploy → filesystem is the right shared store. If this ever runs as multiple instances, move the store to Postgres/Redis (noted in the file).

## Verification

- `tsc --noEmit` passes.
- Round-trip script (run via `tsx`) confirms: store→serve matches byte-for-byte, malformed tokens rejected, unknown tokens return `null`.
- **Not yet verified against a live call** — needs a redeploy, then a test call should connect and play the Goggins audio. Logs will now show `audio stored` → `audio served`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)