### PR TITLE
Improve new-quest UX: required due date, readable date inputs, collapsible Schedule

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -146,6 +146,41 @@
   color: #3a2410;
 }
 
+/* ── Native date/time inputs on parchment surfaces ── */
+/* WebKit (Safari) renders the date/time digits — and the empty placeholder
+   today's-date hint — using -webkit-text-fill-color, NOT the `color` property.
+   Under a dark color-scheme that fill is a faint tone that reads pinkish and
+   illegible on parchment. color-scheme:light fixes the picker icon; the
+   text-fill override is what makes the digits match the other fields. */
+.parchment-context input[type="date"],
+.parchment-context input[type="time"] {
+  color-scheme: light;
+  color: #3a2410;
+  -webkit-text-fill-color: #3a2410;
+}
+
+.parchment-context input[type="date"]::-webkit-datetime-edit,
+.parchment-context input[type="time"]::-webkit-datetime-edit,
+.parchment-context input[type="date"]::-webkit-datetime-edit-fields-wrapper,
+.parchment-context input[type="time"]::-webkit-datetime-edit-fields-wrapper,
+.parchment-context input[type="date"]::-webkit-datetime-edit-text,
+.parchment-context input[type="time"]::-webkit-datetime-edit-text,
+.parchment-context input[type="date"]::-webkit-datetime-edit-month-field,
+.parchment-context input[type="date"]::-webkit-datetime-edit-day-field,
+.parchment-context input[type="date"]::-webkit-datetime-edit-year-field,
+.parchment-context input[type="time"]::-webkit-datetime-edit-hour-field,
+.parchment-context input[type="time"]::-webkit-datetime-edit-minute-field,
+.parchment-context input[type="time"]::-webkit-datetime-edit-ampm-field {
+  color: #3a2410;
+  -webkit-text-fill-color: #3a2410;
+}
+
+.parchment-context input[type="date"]::-webkit-calendar-picker-indicator,
+.parchment-context input[type="time"]::-webkit-calendar-picker-indicator {
+  opacity: 0.55;
+  cursor: pointer;
+}
+
 /* ── Ink-Wash Glassmorphism (Dark Timber) ── */
 .vellum-overlay {
   background: rgba(44, 24, 16, 0.85);

--- a/src/components/inventory/inventory-panel.tsx
+++ b/src/components/inventory/inventory-panel.tsx
@@ -10,6 +10,15 @@ import { QuestEditModal } from "./quest-edit-modal";
 export function InventoryPanel() {
   const { tasks, blocks, toggleTaskDone, addTask, updateTask, deleteTask, updateBlockType } = usePlanner();
   const [editingTask, setEditingTask] = useState<Task | null>(null);
+  const [isNewTask, setIsNewTask] = useState(false);
+
+  const handleAddTask = async (title: string) => {
+    const created = await addTask(title);
+    if (created) {
+      setIsNewTask(true);
+      setEditingTask(created);
+    }
+  };
 
   const editingBlock = editingTask
     ? blocks.find((b) => b.taskId === editingTask.id) ?? null
@@ -38,7 +47,7 @@ export function InventoryPanel() {
           Your quests and tasks, sorted by urgency.
         </p>
       </div>
-      <AddTaskInput onAdd={addTask} />
+      <AddTaskInput onAdd={handleAddTask} />
       <div className="flex-1 overflow-y-auto archivist-scroll">
         <TaskGroup title="Active Quests" tasks={grouped.scheduled} onToggleDone={toggleTaskDone} onEdit={setEditingTask} />
         <TaskGroup title="Unscheduled" tasks={grouped.unscheduled} onToggleDone={toggleTaskDone} onEdit={setEditingTask} />
@@ -48,7 +57,11 @@ export function InventoryPanel() {
       <QuestEditModal
         task={editingTask}
         timeBlock={editingBlock}
-        onClose={() => setEditingTask(null)}
+        isNew={isNewTask}
+        onClose={() => {
+          setEditingTask(null);
+          setIsNewTask(false);
+        }}
         onSave={updateTask}
         onDelete={deleteTask}
         onBlockTypeChange={updateBlockType}

--- a/src/components/inventory/quest-edit-modal.tsx
+++ b/src/components/inventory/quest-edit-modal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { collapseVariants } from "@/lib/animations";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
@@ -12,6 +13,7 @@ import * as api from "@/lib/api-client";
 interface QuestEditModalProps {
   task: Task | null;
   timeBlock?: TimeBlock | null;
+  isNew?: boolean;
   onClose: () => void;
   onSave: (taskId: string, updates: Partial<Task>, startTime?: string) => void;
   onDelete: (taskId: string) => void;
@@ -47,16 +49,28 @@ const blockTypes: { value: BlockType; label: string; emoji: string }[] = [
   { value: "admin", label: "Admin", emoji: "📋" },
 ];
 
-export function QuestEditModal({ task, timeBlock, onClose, onSave, onDelete, onBlockTypeChange }: QuestEditModalProps) {
+function formatTime(t: string): string {
+  if (!t) return "";
+  const [h, m] = t.split(":").map(Number);
+  const ampm = h >= 12 ? "PM" : "AM";
+  const hh = h % 12 || 12;
+  return `${hh}:${String(m).padStart(2, "0")} ${ampm}`;
+}
+
+export function QuestEditModal({ task, timeBlock, isNew = false, onClose, onSave, onDelete, onBlockTypeChange }: QuestEditModalProps) {
   const [title, setTitle] = useState("");
   const [notes, setNotes] = useState("");
   const [priority, setPriority] = useState<Priority>("medium");
   const [dueDate, setDueDate] = useState("");
-  const [estimateMinutes, setEstimateMinutes] = useState(30);
+  const [estimate, setEstimate] = useState("");
   const [startTime, setStartTime] = useState("");
   const [blockType, setBlockType] = useState<BlockType>("focus");
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [scheduleOpen, setScheduleOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
+  // Tracks whether a new quest was committed via Save, so closing afterward
+  // doesn't discard it as a cancelled draft.
+  const savedRef = useRef(false);
 
   useEffect(() => {
     if (task) {
@@ -64,8 +78,11 @@ export function QuestEditModal({ task, timeBlock, onClose, onSave, onDelete, onB
       setNotes(task.notes ?? "");
       setPriority(task.priority);
       setDueDate(task.dueDate ?? "");
-      setEstimateMinutes(task.estimateMinutes);
       setConfirmingDelete(false);
+      savedRef.current = false;
+
+      // New quests start with no estimate or start time — scheduling is opt-in.
+      setEstimate(isNew ? "" : String(task.estimateMinutes));
 
       // Extract time and type from linked block
       if (timeBlock) {
@@ -77,8 +94,11 @@ export function QuestEditModal({ task, timeBlock, onClose, onSave, onDelete, onB
       } else {
         setStartTime("");
       }
+
+      // Reveal the Schedule section only when there's already something to see.
+      setScheduleOpen(!!timeBlock);
     }
-  }, [task, timeBlock]);
+  }, [task, timeBlock, isNew]);
 
   // Lock body scroll when open
   useEffect(() => {
@@ -90,14 +110,22 @@ export function QuestEditModal({ task, timeBlock, onClose, onSave, onDelete, onB
     }
   }, [task]);
 
+  const canSave = title.trim().length > 0 && (!isNew || dueDate.trim().length > 0);
+
   const handleSave = useCallback(() => {
-    if (!task || !title.trim()) return;
+    if (!task || !canSave) return;
     const updates: Partial<Task> = {};
     if (title !== task.title) updates.title = title;
     if ((notes || undefined) !== task.notes) updates.notes = notes || undefined;
     if (priority !== task.priority) updates.priority = priority;
     if ((dueDate || undefined) !== task.dueDate) updates.dueDate = dueDate || undefined;
-    if (estimateMinutes !== task.estimateMinutes) updates.estimateMinutes = estimateMinutes;
+
+    // Estimate is optional in the UI — only persist a deliberate value.
+    // Left blank, the quest keeps its stored default (used by the scheduler).
+    const parsedEstimate = estimate.trim() === "" ? undefined : Math.max(5, Number(estimate) || 5);
+    if (parsedEstimate !== undefined && parsedEstimate !== task.estimateMinutes) {
+      updates.estimateMinutes = parsedEstimate;
+    }
 
     // Determine if start time changed
     const existingTime = timeBlock
@@ -125,8 +153,18 @@ export function QuestEditModal({ task, timeBlock, onClose, onSave, onDelete, onB
       onBlockTypeChange?.(timeBlock.id, blockType);
     }
 
+    savedRef.current = true;
     onClose();
-  }, [task, title, notes, priority, dueDate, estimateMinutes, startTime, timeBlock, blockType, onSave, onClose]);
+  }, [task, canSave, title, notes, priority, dueDate, estimate, startTime, timeBlock, blockType, onSave, onBlockTypeChange, onClose]);
+
+  // Closing without saving a brand-new quest discards the draft, so the
+  // mandatory due date can't be bypassed by dismissing the modal.
+  const handleClose = useCallback(() => {
+    if (isNew && !savedRef.current && task) {
+      onDelete(task.id);
+    }
+    onClose();
+  }, [isNew, task, onDelete, onClose]);
 
   const handleDelete = useCallback(() => {
     if (!task) return;
@@ -140,7 +178,7 @@ export function QuestEditModal({ task, timeBlock, onClose, onSave, onDelete, onB
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") handleClose();
       // Trap focus within the modal
       if (e.key === "Tab" && panelRef.current) {
         const focusable = panelRef.current.querySelectorAll<HTMLElement>(
@@ -158,8 +196,12 @@ export function QuestEditModal({ task, timeBlock, onClose, onSave, onDelete, onB
         }
       }
     },
-    [onClose]
+    [handleClose]
   );
+
+  const scheduleSummary = startTime
+    ? `${formatTime(startTime)}${estimate.trim() ? ` · ${estimate.trim()} min` : ""}`
+    : "Not scheduled";
 
   return (
     <AnimatePresence>
@@ -175,7 +217,7 @@ export function QuestEditModal({ task, timeBlock, onClose, onSave, onDelete, onB
           {/* Backdrop */}
           <motion.div
             className="absolute inset-0 bg-scrim/40"
-            onClick={onClose}
+            onClick={handleClose}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -186,7 +228,7 @@ export function QuestEditModal({ task, timeBlock, onClose, onSave, onDelete, onB
             ref={panelRef}
             role="dialog"
             aria-modal="true"
-            aria-label="Edit quest"
+            aria-label={isNew ? "New quest" : "Edit quest"}
             className="relative w-full sm:max-w-md sm:max-h-[85vh] bg-surface-container-lowest sm:border-2 sm:border-primary/20 flex flex-col flex-1 sm:flex-initial min-h-0"
             initial={{ y: "100%", opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
@@ -197,10 +239,10 @@ export function QuestEditModal({ task, timeBlock, onClose, onSave, onDelete, onB
               {/* Header */}
               <div className="flex items-center justify-between">
                 <h2 className="font-display text-headline-md text-on-surface uppercase tracking-wider">
-                  Edit Quest
+                  {isNew ? "New Quest" : "Edit Quest"}
                 </h2>
                 <button
-                  onClick={onClose}
+                  onClick={handleClose}
                   className="text-outline-variant hover:text-on-surface transition-colors p-1"
                   aria-label="Close"
                 >
@@ -253,94 +295,151 @@ export function QuestEditModal({ task, timeBlock, onClose, onSave, onDelete, onB
                 </div>
               </div>
 
-              {/* Block Type (only for scheduled quests) */}
-              {timeBlock && (
-                <div className="flex flex-col gap-micro">
-                  <span className="font-label text-label-sm font-medium tracking-wide uppercase text-on-surface-variant">
-                    Type
-                  </span>
-                  <div className="flex flex-wrap gap-2">
-                    {blockTypes.map((bt) => (
-                      <button
-                        key={bt.value}
-                        onClick={() => setBlockType(bt.value)}
-                        className={cn(
-                          "px-3 py-1.5 font-label text-label-sm font-medium tracking-wide rounded-none transition-all duration-200 flex items-center gap-1.5",
-                          blockType === bt.value
-                            ? "bg-tertiary/15 text-tertiary border-b border-tertiary/30"
-                            : "text-on-surface-variant border-b border-transparent hover:opacity-80"
-                        )}
-                      >
-                        <span>{bt.emoji}</span>
-                        {bt.label}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Due Date & Start Time row */}
-              <div className="grid grid-cols-2 gap-3">
+              {/* Due Date (required) */}
+              <div className="flex flex-col gap-micro">
                 <Input
                   id="quest-due-date"
-                  label="Due Date"
+                  label={isNew ? "Due Date *" : "Due Date"}
                   type="date"
                   value={dueDate}
                   onChange={(e) => setDueDate(e.target.value)}
+                  className="[color-scheme:light]"
                 />
-                <Input
-                  id="quest-start-time"
-                  label="Start Time"
-                  type="time"
-                  value={startTime}
-                  onChange={(e) => setStartTime(e.target.value)}
-                />
+                {isNew && !dueDate.trim() && (
+                  <p className="font-label text-label-sm text-tertiary">
+                    Set a due date to create this quest.
+                  </p>
+                )}
               </div>
 
-              {/* Estimate */}
-              <div className="flex flex-col gap-micro">
-                <label
-                  htmlFor="quest-estimate"
-                  className="font-label text-label-sm font-medium tracking-wide uppercase text-on-surface-variant"
+              {/* Schedule (collapsible) */}
+              <div className="border-t border-outline-variant/20 pt-4">
+                <button
+                  type="button"
+                  onClick={() => setScheduleOpen((o) => !o)}
+                  aria-expanded={scheduleOpen}
+                  aria-controls="quest-schedule-panel"
+                  className="flex items-center gap-2 w-full text-left"
                 >
-                  Estimate
-                </label>
-                <div className="relative w-32">
-                  <input
-                    id="quest-estimate"
-                    type="number"
-                    min={5}
-                    step={5}
-                    value={estimateMinutes}
-                    onChange={(e) => setEstimateMinutes(Number(e.target.value) || 5)}
+                  <svg
                     className={cn(
-                      "w-full bg-surface-container-high border-0 border-b-2 border-primary/30 rounded-none",
-                      "px-3 py-2.5 pr-10 font-body text-body-lg text-on-surface",
-                      "focus:border-tertiary focus:outline-none",
-                      "transition-colors duration-200"
+                      "w-3 h-3 text-on-surface-variant transition-transform duration-200",
+                      scheduleOpen && "rotate-90"
                     )}
-                  />
-                  <span className="absolute right-3 top-1/2 -translate-y-1/2 font-label text-label-sm text-outline-variant">
-                    min
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                  >
+                    <polyline points="9 18 15 12 9 6" />
+                  </svg>
+                  <span className="font-label text-label-sm font-medium tracking-wide uppercase text-on-surface-variant">
+                    Schedule
                   </span>
-                </div>
+                  {!scheduleOpen && (
+                    <span className="ml-auto font-label text-label-sm text-outline-variant">
+                      {scheduleSummary}
+                    </span>
+                  )}
+                </button>
+
+                <AnimatePresence initial={false}>
+                  {scheduleOpen && (
+                    <motion.div
+                      id="quest-schedule-panel"
+                      variants={collapseVariants}
+                      initial="closed"
+                      animate="open"
+                      exit="closed"
+                      className="overflow-hidden"
+                    >
+                      <div className="pt-4 space-y-4">
+                        {/* Start Time */}
+                        <Input
+                          id="quest-start-time"
+                          label="Start Time"
+                          type="time"
+                          value={startTime}
+                          onChange={(e) => setStartTime(e.target.value)}
+                          className="[color-scheme:light]"
+                        />
+
+                        {/* Block Type (only for scheduled quests) */}
+                        {timeBlock && (
+                          <div className="flex flex-col gap-micro">
+                            <span className="font-label text-label-sm font-medium tracking-wide uppercase text-on-surface-variant">
+                              Type
+                            </span>
+                            <div className="flex flex-wrap gap-2">
+                              {blockTypes.map((bt) => (
+                                <button
+                                  key={bt.value}
+                                  onClick={() => setBlockType(bt.value)}
+                                  className={cn(
+                                    "px-3 py-1.5 font-label text-label-sm font-medium tracking-wide rounded-none transition-all duration-200 flex items-center gap-1.5",
+                                    blockType === bt.value
+                                      ? "bg-tertiary/15 text-tertiary border-b border-tertiary/30"
+                                      : "text-on-surface-variant border-b border-transparent hover:opacity-80"
+                                  )}
+                                >
+                                  <span>{bt.emoji}</span>
+                                  {bt.label}
+                                </button>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Estimate */}
+                        <div className="flex flex-col gap-micro">
+                          <label
+                            htmlFor="quest-estimate"
+                            className="font-label text-label-sm font-medium tracking-wide uppercase text-on-surface-variant"
+                          >
+                            Estimate
+                          </label>
+                          <div className="relative w-32">
+                            <input
+                              id="quest-estimate"
+                              type="number"
+                              min={5}
+                              step={5}
+                              value={estimate}
+                              onChange={(e) => setEstimate(e.target.value)}
+                              placeholder="30"
+                              className={cn(
+                                "w-full bg-surface-container-high border-0 border-b-2 border-primary/30 rounded-none",
+                                "px-3 py-2.5 pr-10 font-body text-body-lg text-on-surface",
+                                "placeholder:text-outline-variant",
+                                "focus:border-tertiary focus:outline-none",
+                                "transition-colors duration-200"
+                              )}
+                            />
+                            <span className="absolute right-3 top-1/2 -translate-y-1/2 font-label text-label-sm text-outline-variant">
+                              min
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
               </div>
 
               {/* Footer */}
               <div className="flex items-center justify-between p-5 pt-3 border-t border-outline-variant/20 pb-[calc(0.75rem+env(safe-area-inset-bottom))] sm:pb-5">
-                <Button
-                  variant="ghost"
-                  onClick={handleDelete}
-                  className="text-error"
-                >
-                  {confirmingDelete ? "Confirm Delete" : "Delete"}
-                </Button>
-                <Button
-                  variant="primary"
-                  onClick={handleSave}
-                  disabled={!title.trim()}
-                >
-                  Save
+                {isNew ? (
+                  <Button variant="ghost" onClick={handleClose}>
+                    Cancel
+                  </Button>
+                ) : (
+                  <Button variant="ghost" onClick={handleDelete} className="text-error">
+                    {confirmingDelete ? "Confirm Delete" : "Delete"}
+                  </Button>
+                )}
+                <Button variant="primary" onClick={handleSave} disabled={!canSave}>
+                  {isNew ? "Create Quest" : "Save"}
                 </Button>
               </div>
             </div>

--- a/src/context/planner-context.tsx
+++ b/src/context/planner-context.tsx
@@ -67,7 +67,7 @@ interface PlannerState {
 interface PlannerActions {
   sendMessage: (content: string) => void;
   toggleTaskDone: (taskId: string) => void;
-  addTask: (title: string) => void;
+  addTask: (title: string) => Promise<Task | null>;
   updateTask: (taskId: string, updates: Partial<Task>, startTime?: string) => void;
   deleteTask: (taskId: string) => void;
   updateBlockType: (blockId: string, blockType: string) => void;
@@ -305,12 +305,14 @@ export function PlannerProvider({ children }: { children: ReactNode }) {
 
     try {
       const created = await api.createTask({ title });
+      const createdTask = dbTaskToTask(created as any);
       setTasks((prev) =>
-        prev.map((t) => (t.id === tempId ? dbTaskToTask(created as any) : t))
+        prev.map((t) => (t.id === tempId ? createdTask : t))
       );
+      return createdTask;
     } catch (err) {
-
       setTasks((prev) => prev.filter((t) => t.id !== tempId));
+      return null;
     }
   }, []);
 


### PR DESCRIPTION
## Summary

Improves the experience of adding and editing quests, addressing four issues:

1. **Due date is now mandatory for new quests.** The quick-add stays a fast title-only capture, but on add it opens the edit modal flagged as *new* with **Create Quest** disabled until a due date is set. Dismissing a brand-new quest (Cancel / Escape / backdrop / ✕) discards the draft, so the requirement can't be bypassed.
2. **Fixed unreadable date/time inputs** on the parchment modal. In Safari the native digits — including the empty-field "today's date" placeholder — are painted with `-webkit-text-fill-color`, not `color`. Under the app's dark `color-scheme` that fill rendered a faint pinkish tone, illegible on parchment, and `color` / `color-scheme: light` couldn't override it. Verified the root cause and fix in headless WebKit. Fix is scoped to `.parchment-context`.
3. **Grouped calendar scheduling into one collapsible "Schedule" subsection** (Start Time, Type, Estimate), collapsed by default with a summary (`Not scheduled` / `2:00 PM · 45 min`) and auto-expanded when a quest is already scheduled. Due Date stays in the always-visible area since it's a deadline, not calendar data.
4. **New quests default to empty start time and estimate.** Left blank, the stored 30-min default still backs the scheduler — you're never forced to type it.

## Changes
- `quest-edit-modal.tsx` — required due date for new quests, draft-discard on cancel, collapsible Schedule section, empty defaults, `New Quest` / `Create Quest` labels.
- `inventory-panel.tsx` — quick-add auto-opens the modal flagged `isNew`.
- `planner-context.tsx` — `addTask` returns the created `Task`.
- `globals.css` — `-webkit-text-fill-color` ink override for date/time inputs on parchment.

## Tradeoff to be aware of
Safari renders an empty date field as today's date placeholder. Now that digits are forced dark, an *unset* due date looks filled — the amber hint and disabled Create button signal it's empty. A muted empty-state treatment is an easy follow-up if desired.

## Testing
- `tsc --noEmit` passes.
- Date/time input fix verified in headless WebKit (matches Safari engine).
- No automated test suite in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)