### PR TITLE
feat: 'new version available' banner on deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN npm run build
 FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+# Build stamp (git short SHA) so the running app can detect new deployments.
+ARG APP_VERSION=dev
+ENV APP_VERSION=$APP_VERSION
 
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,6 +7,10 @@ COMPOSE_FILE="docker-compose.prod.yml"
 echo "==> Pulling latest code..."
 git pull origin main
 
+# Stamp the build with the deployed commit so the app can detect new versions.
+export APP_VERSION="$(git rev-parse --short HEAD)"
+echo "==> Building APP_VERSION=$APP_VERSION"
+
 # Bring up the database first (no-op if already running) so the schema can be
 # applied before the new app container starts serving — additive schema changes
 # are backward-compatible, so the currently-running app tolerates them.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,6 +23,7 @@ services:
       args:
         NEXT_PUBLIC_WS_PORT: "8443"
         NEXT_PUBLIC_GOGGINS_CALLS_ENABLED: "${NEXT_PUBLIC_GOGGINS_CALLS_ENABLED:-false}"
+        APP_VERSION: "${APP_VERSION:-dev}"
     restart: unless-stopped
     ports:
       - "127.0.0.1:3000:3000"

--- a/docs/superpowers/plans/2026-06-29-update-available-banner.md
+++ b/docs/superpowers/plans/2026-06-29-update-available-banner.md
@@ -1,0 +1,359 @@
+# Update-Available Banner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a passive, dismissible banner when a newer deployment is live, prompting the user to refresh.
+
+**Architecture:** The server stamps each new `/api/events` WebSocket connection with its build version (`app_version` message). A deploy restarts the server, dropping every socket; the existing 3 s auto-reconnect re-delivers the new version. The client records the first version as baseline and shows the banner when a later version differs.
+
+**Tech Stack:** Next.js 15 / React 19 / TypeScript, custom Node `ws` server (`server.ts`), Tailwind 4, Framer Motion, Docker Compose.
+
+## Global Constraints
+
+- **No new test infrastructure.** The repo has no test runner; verification is manual (build + browser). Do not add vitest/jest/etc.
+- **Banner copy (verbatim):** `A new version of Runekeeper is available.`
+- **Event shape (verbatim):** `{ "type": "app_version", "version": "<string>" }`.
+- **Version fallback:** when `process.env.APP_VERSION` is unset, the server reports the literal string `dev`.
+- **0px corners:** UI uses `rounded-none` by default; do not add rounded corners (reuse the shared `Button`).
+- **Theme tokens:** dark `bg-surface-dim` (#1a1008), gold accents `rgba(212,168,96,*)`, `text-on-surface`, `font-body`, `text-body-md`. Fonts/sizes already defined in `globals.css`.
+- **Per-task type check:** `npx tsc --noEmit` must pass. Final integration check: `npm run build`.
+
+---
+
+### Task 1: Server emits `app_version` on `/api/events` connect
+
+**Files:**
+- Modify: `server.ts` (inside the `/api/events` `wss.handleUpgrade` callback, around `server.ts:73-79`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: each `/api/events` client receives, as its first frame, the JSON string `{"type":"app_version","version":"<APP_VERSION or 'dev'>"}`.
+
+- [ ] **Step 1: Send the version frame on connect**
+
+In `server.ts`, inside the `wss.handleUpgrade(req, socket, head, (clientWs) => { ... })` block for `pathname === "/api/events"`, immediately after the `eventConnections.get(user.id)!.add(clientWs);` line (currently `server.ts:78`), add:
+
+```ts
+        // Tell the client which build it just connected to. A deploy restarts
+        // the server, so a reconnect re-delivers this with a new value, which
+        // the client uses to detect that a newer version is live.
+        clientWs.send(
+          JSON.stringify({ type: "app_version", version: process.env.APP_VERSION || "dev" })
+        );
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: exits 0, no errors.
+
+- [ ] **Step 3: Verify the frame is sent**
+
+Run the dev server in one terminal: `APP_VERSION=test-v1 npm run dev`
+In a browser DevTools console (while signed in, on `/planner`), open the Network tab → WS → `/api/events` connection → Messages. Confirm the first received message is `{"type":"app_version","version":"test-v1"}`.
+(If not signed in, the upgrade returns 401 — sign in first.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server.ts
+git commit -m "feat(server): send app_version on events websocket connect"
+```
+
+---
+
+### Task 2: Client `useAppVersion` hook
+
+**Files:**
+- Create: `src/hooks/use-app-version.ts`
+
+**Interfaces:**
+- Consumes: `useEventSocket(onEvent: (event: Record<string, unknown>) => void)` from `@/hooks/use-event-socket`, and the `app_version` frame from Task 1.
+- Produces: `useAppVersion(): { updateAvailable: boolean; dismiss: () => void }`.
+
+- [ ] **Step 1: Create the hook**
+
+Create `src/hooks/use-app-version.ts`:
+
+```ts
+"use client";
+
+import { useCallback, useState } from "react";
+import { useEventSocket } from "@/hooks/use-event-socket";
+
+/**
+ * Detects when a newer deployment is live.
+ *
+ * The server sends an `app_version` frame on every `/api/events` connection.
+ * We treat the first version we see as the baseline (the build this tab loaded
+ * with). A deploy restarts the server, so the socket reconnects and reports a
+ * different version — at which point `updateAvailable` becomes true.
+ *
+ * `dismiss()` advances the baseline to the version currently advertised, hiding
+ * the banner until a *further*, different version arrives.
+ */
+export function useAppVersion(): { updateAvailable: boolean; dismiss: () => void } {
+  const [baseline, setBaseline] = useState<string | null>(null);
+  const [latest, setLatest] = useState<string | null>(null);
+
+  const handleEvent = useCallback((event: Record<string, unknown>) => {
+    if (event.type !== "app_version" || typeof event.version !== "string") return;
+    const version = event.version;
+    setBaseline((current) => current ?? version); // set once, on first frame
+    setLatest(version);
+  }, []);
+
+  useEventSocket(handleEvent);
+
+  const dismiss = useCallback(() => {
+    setBaseline((current) => latest ?? current);
+  }, [latest]);
+
+  const updateAvailable = baseline !== null && latest !== null && latest !== baseline;
+
+  return { updateAvailable, dismiss };
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: exits 0, no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/use-app-version.ts
+git commit -m "feat(hooks): add useAppVersion to detect new deployments"
+```
+
+---
+
+### Task 3: `UpdateBanner` component + mount in planner shell
+
+**Files:**
+- Create: `src/components/update-banner.tsx`
+- Modify: `src/app/planner/planner-shell.tsx` (import + render, near `planner-shell.tsx:208-211`)
+
+**Interfaces:**
+- Consumes: `useAppVersion()` from Task 2; `Button` from `@/components/ui/button`.
+- Produces: `<UpdateBanner />` (default export not used — named export `UpdateBanner`).
+
+- [ ] **Step 1: Create the banner component**
+
+Create `src/components/update-banner.tsx`:
+
+```tsx
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { Button } from "@/components/ui/button";
+import { useAppVersion } from "@/hooks/use-app-version";
+
+/**
+ * Passive, dismissible banner shown when a newer build is deployed.
+ * Bottom-center, above the mobile bottom nav (z-40) and sidebar overlay (z-50).
+ */
+export function UpdateBanner() {
+  const { updateAvailable, dismiss } = useAppVersion();
+
+  return (
+    <AnimatePresence>
+      {updateAvailable && (
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 24 }}
+          transition={{ duration: 0.25, ease: "easeOut" }}
+          role="status"
+          aria-live="polite"
+          className="fixed bottom-4 left-1/2 z-[60] mb-16 flex max-w-[calc(100vw-2rem)] -translate-x-1/2 items-center gap-3 border border-[rgba(212,168,96,0.35)] bg-surface-dim px-4 py-3 shadow-lg lg:mb-0"
+        >
+          <svg
+            className="h-4 w-4 shrink-0 text-primary"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path d="M12 2l2.4 6.9L21 9.3l-5.2 4.2L17.6 21 12 16.9 6.4 21l1.8-7.5L3 9.3l6.6-.4z" />
+          </svg>
+          <span className="font-body text-body-md text-on-surface">
+            A new version of Runekeeper is available.
+          </span>
+          <Button
+            variant="primary"
+            onClick={() => window.location.reload()}
+            className="px-4 py-1.5"
+          >
+            Refresh
+          </Button>
+          <button
+            onClick={dismiss}
+            aria-label="Dismiss update notification"
+            className="shrink-0 text-on-surface-variant transition-colors duration-200 hover:text-on-surface"
+          >
+            <svg
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+```
+
+- [ ] **Step 2: Import the banner in the planner shell**
+
+In `src/app/planner/planner-shell.tsx`, add this import alongside the other component imports (after `planner-shell.tsx:17`, the `OnboardingOverlay` import):
+
+```tsx
+import { UpdateBanner } from "@/components/update-banner";
+```
+
+- [ ] **Step 3: Render the banner**
+
+In `src/app/planner/planner-shell.tsx`, inside the root `<div className="flex h-dvh overflow-hidden">`, just before its closing `</div>` (immediately after the onboarding `AnimatePresence` block at `planner-shell.tsx:209-211`), add:
+
+```tsx
+      {/* New-deployment notice */}
+      <UpdateBanner />
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: exits 0, no errors.
+
+- [ ] **Step 5: Verify the banner renders (temporary trigger)**
+
+The banner won't trigger in normal dev (single stable version). To visually confirm rendering, temporarily change the hook's last line in `src/hooks/use-app-version.ts` to `const updateAvailable = true;`, run `npm run dev`, load `/planner`, and confirm the banner appears bottom-center with Refresh + ✕ and clears the mobile bottom nav. **Then revert that line** back to:
+`const updateAvailable = baseline !== null && latest !== null && latest !== baseline;`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/update-banner.tsx src/app/planner/planner-shell.tsx
+git commit -m "feat(ui): add update-available banner to planner shell"
+```
+
+---
+
+### Task 4: Version source — Docker build arg through deploy
+
+**Files:**
+- Modify: `Dockerfile` (runner stage, after `ENV NODE_ENV=production` near `Dockerfile:27`)
+- Modify: `docker-compose.prod.yml` (`app.build.args`)
+- Modify: `deploy.sh` (after `git pull origin main`, around `deploy.sh:8`)
+
+**Interfaces:**
+- Consumes: git short SHA at deploy time.
+- Produces: `process.env.APP_VERSION` set to that SHA in the running container (read by Task 1).
+
+- [ ] **Step 1: Accept `APP_VERSION` in the runner stage**
+
+In `Dockerfile`, in the `runner` stage, immediately after the existing `ENV NODE_ENV=production` line (the one in the `runner` stage, `Dockerfile:27`), add:
+
+```dockerfile
+ARG APP_VERSION=dev
+ENV APP_VERSION=$APP_VERSION
+```
+
+- [ ] **Step 2: Forward the build arg in compose**
+
+In `docker-compose.prod.yml`, under `services.app.build.args`, add a line alongside the existing args:
+
+```yaml
+        APP_VERSION: "${APP_VERSION:-dev}"
+```
+
+The `args` block then reads:
+
+```yaml
+      args:
+        NEXT_PUBLIC_WS_PORT: "8443"
+        NEXT_PUBLIC_GOGGINS_CALLS_ENABLED: "${NEXT_PUBLIC_GOGGINS_CALLS_ENABLED:-false}"
+        APP_VERSION: "${APP_VERSION:-dev}"
+```
+
+- [ ] **Step 3: Export the SHA in deploy.sh**
+
+In `deploy.sh`, immediately after the `git pull origin main` line (`deploy.sh:8`), add:
+
+```sh
+# Stamp the build with the deployed commit so the app can detect new versions.
+export APP_VERSION="$(git rev-parse --short HEAD)"
+echo "==> Building APP_VERSION=$APP_VERSION"
+```
+
+(Compose interpolates `${APP_VERSION}` from the exported shell variable when it runs `docker compose ... up -d --build` later in the script.)
+
+- [ ] **Step 4: Validate compose config resolves the arg**
+
+Run: `APP_VERSION=abc123 docker compose -f docker-compose.prod.yml config 2>/dev/null | grep -A6 'args:'`
+Expected: the rendered `args` section shows `APP_VERSION: abc123`.
+(If Docker is unavailable in the working environment, skip this and rely on Task 5's run-based check.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Dockerfile docker-compose.prod.yml deploy.sh
+git commit -m "feat(deploy): stamp APP_VERSION (git sha) into the runtime image"
+```
+
+---
+
+### Task 5: Manual end-to-end verification
+
+**Files:** none (verification only).
+
+**Interfaces:**
+- Consumes: Tasks 1-3 (Task 4's plumbing is exercised in prod; dev simulates it via the `APP_VERSION` env var).
+
+- [ ] **Step 1: Start at version 1**
+
+Run: `APP_VERSION=v1 npm run dev`
+Sign in and open `/planner`. Confirm (DevTools → Network → WS → `/api/events` → Messages) the first frame is `{"type":"app_version","version":"v1"}` and **no banner is shown**.
+
+- [ ] **Step 2: Simulate a deploy**
+
+Stop the dev server (Ctrl-C) and restart with a different version:
+Run: `APP_VERSION=v2 npm run dev`
+
+- [ ] **Step 3: Confirm the banner appears**
+
+Without reloading the browser, wait up to ~3 s for the WS auto-reconnect. Confirm:
+- The reconnected socket's first frame is `{"type":"app_version","version":"v2"}`.
+- The banner slides in bottom-center with the exact copy `A new version of Runekeeper is available.`
+
+- [ ] **Step 4: Confirm dismiss and refresh**
+
+- Click **✕** → the banner dismisses and stays gone (no further deploy).
+- Reload manually, repeat Steps 1-3, then click **Refresh** → the page reloads and the banner is gone (now running v2 as the new baseline).
+
+- [ ] **Step 5: Confirm dev fallback is silent**
+
+Run plain `npm run dev` (no `APP_VERSION`), restart it once. Confirm the reported version is `dev` both times and the banner never appears.
+
+- [ ] **Step 6: Final integration build**
+
+Run: `npm run build`
+Expected: build succeeds with no type or lint errors.
+
+---
+
+## Notes for the executor
+
+- Tasks 1-3 are the functional core and can be verified in dev. Task 4 only takes effect in the Docker/prod deploy path; its correctness is validated by the compose `config` check (Step 4) plus the existing deploy flow.
+- The hook opens a **second** `/api/events` socket (the only other consumer, `ChatContainer`, mounts solely on the chat view). This is intentional and supported — the server tracks multiple sockets per user.
+- Do not leave the temporary `const updateAvailable = true;` change from Task 3 Step 5 in place; it must be reverted before committing that task.

--- a/docs/superpowers/specs/2026-06-29-update-available-banner-design.md
+++ b/docs/superpowers/specs/2026-06-29-update-available-banner-design.md
@@ -1,0 +1,165 @@
+# Design: "New version available" banner
+
+**Date:** 2026-06-29
+**Status:** Approved (pending spec review)
+
+## Problem
+
+After a production deploy, users keep running the previously-loaded bundle until
+they manually refresh. There is no signal that a newer version exists, so users
+unknowingly use a stale app (observed in practice 2026-06-29).
+
+## Goal
+
+Show a small, passive, dismissible banner when the running deployment is newer
+than the version the current tab loaded, prompting the user to refresh. No forced
+reloads — the user might have unsaved state (chat draft, in-progress planner edits).
+
+## Approach: reuse the existing WebSocket
+
+The app already has an authenticated WebSocket events channel at `/api/events`
+(`src/hooks/use-event-socket.ts`) that **auto-reconnects 3 s after any drop**
+(`use-event-socket.ts:39-43`). In the Docker deploy flow a release is a new
+container, so the server process restarts, every `/api/events` socket drops, and
+each client reconnects automatically. That reconnect is a near-instant,
+zero-polling signal that the deployment changed.
+
+Mechanism:
+
+1. Bake a build identifier into the **server runtime** at build time — the git
+   short SHA, exposed as `process.env.APP_VERSION`.
+2. On every new `/api/events` WebSocket connection, the server sends its version
+   as the first message: `{ "type": "app_version", "version": "<sha>" }`.
+3. The client records the **first** version it observes as its baseline (the
+   version its loaded bundle belongs to). On any later message whose version
+   differs from the baseline, a new deployment is live → show the banner.
+
+The client never needs its own version inlined into the bundle; it just remembers
+the first thing the server told it and compares.
+
+### Why this over polling a `/api/version` endpoint
+
+- Near-instant detection on deploy (reconnect fires within ~3 s) vs. up to a full
+  poll interval of lag.
+- Zero periodic network traffic.
+- No build-time version inlining into the client bundle.
+
+Tradeoff: coupled to the WS server being reachable. That is already core infra
+(voice, OMI triggers depend on it), so this is acceptable.
+
+## Components
+
+### 1. Server — emit `app_version` on connect (`server.ts`)
+
+In the `/api/events` upgrade handler, immediately after the client socket is
+established (`server.ts:73-79`), send:
+
+```ts
+clientWs.send(JSON.stringify({
+  type: "app_version",
+  version: process.env.APP_VERSION || "dev",
+}));
+```
+
+When `APP_VERSION` is unset (local dev), the value is `"dev"`, which is stable
+across restarts, so the banner never triggers during development.
+
+### 2. Version source — `Dockerfile`, `docker-compose.prod.yml`, `deploy.sh`
+
+`APP_VERSION` must reach the **runner** stage, because `server.ts` reads it at
+runtime (not build time). Follow the existing `NEXT_PUBLIC_WS_PORT` arg pattern.
+
+- **`Dockerfile`** — add `ARG APP_VERSION=dev` and `ENV APP_VERSION=$APP_VERSION`
+  in the `runner` stage (so it is present in `process.env` at runtime).
+- **`docker-compose.prod.yml`** — under `app.build.args`, add
+  `APP_VERSION: "${APP_VERSION:-dev}"` so compose forwards the host's value.
+- **`deploy.sh`** — after `git pull origin main`, export the SHA so compose
+  interpolation picks it up before `docker compose ... up -d --build`:
+  ```sh
+  export APP_VERSION="$(git rev-parse --short HEAD)"
+  ```
+
+This ties the version string to the exact built image. A redeploy of the same SHA
+produces the same version → no spurious banner.
+
+### 3. Client hook — `src/hooks/use-app-version.ts`
+
+A focused hook that owns its own `/api/events` subscription (via the existing
+`useEventSocket`) and exposes update state plus a dismiss action:
+
+```ts
+export function useAppVersion(): { updateAvailable: boolean; dismiss: () => void }
+```
+
+Behavior:
+- On each event, ignore anything except `{ type: "app_version" }`.
+- First `app_version` seen → store as `baseline`.
+- `updateAvailable` is `true` whenever the latest reported version differs from
+  `baseline`.
+- `dismiss()` advances `baseline` to the latest reported version, so
+  `updateAvailable` returns to `false` until a *further*, different version
+  arrives (which re-triggers the banner). This cleanly encodes the
+  dismiss-then-reappear-on-next-deploy behavior without the component tracking
+  versions itself.
+- A refresh reloads the page and resets all state.
+
+It opens a **second** `/api/events` WebSocket connection. This is intentional: the
+only current `useEventSocket` consumer is `ChatContainer`, which mounts **only
+when the chat view is active** (`planner-shell.tsx:177`), so it cannot provide
+app-wide coverage. The extra connection is one lightweight socket and keeps the
+feature self-contained and independent of the current view. The server already
+tracks multiple sockets per user ("tabs"), so a second connection is supported.
+
+### 4. Banner UI — `src/components/update-banner.tsx`
+
+A presentational component driven by `useAppVersion`.
+
+- Renders nothing while `updateAvailable` is false.
+- When shown: a fixed banner at **bottom-center** (single position, no
+  per-breakpoint switching), animated in with Framer Motion to match existing
+  styling. Copy: "A new version of Runekeeper is available." with a **Refresh**
+  button (`window.location.reload()`) and a dismiss **✕** that calls `dismiss()`.
+- Mounted once in `src/app/planner/planner-shell.tsx` (the persistent shell) so
+  it is present regardless of the active view.
+
+## Behavior & edge cases
+
+- **Dismiss:** `dismiss()` advances the baseline to the version currently being
+  advertised, hiding the banner. If a *further* deploy lands afterward (a third,
+  different SHA), the latest version again differs from the (advanced) baseline,
+  so the banner reappears.
+- **Multiple tabs:** each tab has its own connection and baseline, so each shows
+  the banner independently — correct, since each tab loaded its own bundle.
+- **Reconnect without deploy** (transient network blip): server reports the same
+  version → no banner.
+- **Dev / missing `APP_VERSION`:** server reports `"dev"`; never triggers.
+- **Placement rationale:** single fixed position deliberately avoids the
+  responsive position-switching complexity flagged in prior modal-layout feedback.
+
+## Out of scope (YAGNI)
+
+- Forced/auto reload or countdown (explicitly rejected — risks losing user state).
+- Showing changelog / release notes in the banner.
+- Service-worker-based update detection.
+- A `/api/version` REST endpoint (the WS path supersedes it).
+
+## Testing
+
+- **Server:** unit-check that the `/api/events` connection handler sends a
+  well-formed `app_version` message as its first frame.
+- **Client hook:** with a mocked event stream, assert `updateAvailable` stays
+  false for the baseline and for repeated identical versions, and flips true when
+  a differing version arrives.
+- **Manual:** run prod build with `APP_VERSION=a`, load the app, restart the
+  server with `APP_VERSION=b`, confirm the banner appears within ~3 s and Refresh
+  loads the new build.
+
+## Files touched
+
+- `server.ts` — send `app_version` on `/api/events` connect.
+- `Dockerfile` — `ARG`/`ENV APP_VERSION` in runner stage.
+- `docker-compose.prod.yml` — forward `APP_VERSION` build arg.
+- `deploy.sh` — export git short SHA before build.
+- `src/hooks/use-app-version.ts` — new hook.
+- `src/components/update-banner.tsx` — new component.
+- `src/app/planner/planner-shell.tsx` — mount the banner.

--- a/server.ts
+++ b/server.ts
@@ -78,6 +78,13 @@ app.prepare().then(() => {
         eventConnections.get(user.id)!.add(clientWs);
         console.log(`[events] connected: ${user.name} (${eventConnections.get(user.id)!.size} tabs)`);
 
+        // Tell the client which build it just connected to. A deploy restarts
+        // the server, so a reconnect re-delivers this with a new value, which
+        // the client uses to detect that a newer version is live.
+        clientWs.send(
+          JSON.stringify({ type: "app_version", version: process.env.APP_VERSION || "dev" })
+        );
+
         clientWs.on("close", () => {
           const conns = eventConnections.get(user.id);
           if (conns) {

--- a/src/app/planner/planner-shell.tsx
+++ b/src/app/planner/planner-shell.tsx
@@ -15,6 +15,7 @@ import IntegrationsGraph from "@/components/integrations/integrations-graph";
 import { ProfileView } from "@/components/profile/profile-view";
 import { useOnboarding } from "@/components/onboarding/use-onboarding";
 import { OnboardingOverlay } from "@/components/onboarding/onboarding-overlay";
+import { UpdateBanner } from "@/components/update-banner";
 const viewTitles: Record<ViewId, string> = {
   home: "Hearth",
   chat: "Oracle",
@@ -209,6 +210,9 @@ function PlannerShell() {
       <AnimatePresence>
         {showOnboarding && <OnboardingOverlay onComplete={completeOnboarding} />}
       </AnimatePresence>
+
+      {/* New-deployment notice */}
+      <UpdateBanner />
     </div>
   );
 }

--- a/src/components/update-banner.tsx
+++ b/src/components/update-banner.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { Button } from "@/components/ui/button";
+import { useAppVersion } from "@/hooks/use-app-version";
+
+/**
+ * Passive, dismissible banner shown when a newer build is deployed.
+ * Bottom-center, above the mobile bottom nav (z-40) and sidebar overlay (z-50).
+ */
+export function UpdateBanner() {
+  const { updateAvailable, dismiss } = useAppVersion();
+
+  return (
+    <AnimatePresence>
+      {updateAvailable && (
+        <motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 24 }}
+          transition={{ duration: 0.25, ease: "easeOut" }}
+          role="status"
+          aria-live="polite"
+          className="fixed bottom-4 left-1/2 z-[60] mb-16 flex max-w-[calc(100vw-2rem)] -translate-x-1/2 items-center gap-3 border border-[rgba(212,168,96,0.35)] bg-surface-dim px-4 py-3 shadow-lg lg:mb-0"
+        >
+          <svg
+            className="h-4 w-4 shrink-0 text-primary"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path d="M12 2l2.4 6.9L21 9.3l-5.2 4.2L17.6 21 12 16.9 6.4 21l1.8-7.5L3 9.3l6.6-.4z" />
+          </svg>
+          <span className="font-body text-body-md text-on-surface">
+            A new version of Runekeeper is available.
+          </span>
+          <Button
+            variant="primary"
+            onClick={() => window.location.reload()}
+            className="px-4 py-1.5"
+          >
+            Refresh
+          </Button>
+          <button
+            onClick={dismiss}
+            aria-label="Dismiss update notification"
+            className="shrink-0 text-on-surface-variant transition-colors duration-200 hover:text-on-surface"
+          >
+            <svg
+              className="h-4 w-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/hooks/use-app-version.ts
+++ b/src/hooks/use-app-version.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useEventSocket } from "@/hooks/use-event-socket";
+
+/**
+ * Detects when a newer deployment is live.
+ *
+ * The server sends an `app_version` frame on every `/api/events` connection.
+ * We treat the first version we see as the baseline (the build this tab loaded
+ * with). A deploy restarts the server, so the socket reconnects and reports a
+ * different version — at which point `updateAvailable` becomes true.
+ *
+ * `dismiss()` advances the baseline to the version currently advertised, hiding
+ * the banner until a *further*, different version arrives.
+ */
+export function useAppVersion(): { updateAvailable: boolean; dismiss: () => void } {
+  const [baseline, setBaseline] = useState<string | null>(null);
+  const [latest, setLatest] = useState<string | null>(null);
+
+  const handleEvent = useCallback((event: Record<string, unknown>) => {
+    if (event.type !== "app_version" || typeof event.version !== "string") return;
+    const version = event.version;
+    setBaseline((current) => current ?? version); // set once, on first frame
+    setLatest(version);
+  }, []);
+
+  useEventSocket(handleEvent);
+
+  const dismiss = useCallback(() => {
+    setBaseline((current) => latest ?? current);
+  }, [latest]);
+
+  const updateAvailable = baseline !== null && latest !== null && latest !== baseline;
+
+  return { updateAvailable, dismiss };
+}


### PR DESCRIPTION
## What

Adds a passive, dismissible banner that appears when a newer build is deployed, prompting the user to refresh. Solves users unknowingly running a stale bundle after a deploy.

## How it works

Reuses the existing `/api/events` WebSocket (which already auto-reconnects 3s after any drop). A deploy = new container = server restart = dropped socket = reconnect — a near-instant, zero-polling signal.

- **Server** (`server.ts`): sends `{ type: "app_version", version }` as the first frame on every `/api/events` connection. Version comes from `process.env.APP_VERSION` (git short SHA), falling back to `"dev"`.
- **Client** (`use-app-version.ts`): records the first version it sees as baseline; flips `updateAvailable` true when a later reconnect reports a different version. `dismiss()` advances the baseline so the banner re-arms only on a *further* deploy.
- **UI** (`update-banner.tsx`): bottom-center Framer Motion banner with Refresh + dismiss, mounted in `planner-shell.tsx` (not chat-container, which only mounts on the chat view).
- **Deploy**: `APP_VERSION` (git short SHA) threaded through `Dockerfile` → `docker-compose.prod.yml` → `deploy.sh`, matching the existing `NEXT_PUBLIC_WS_PORT` build-arg pattern.

## Design docs

- Spec: `docs/superpowers/specs/2026-06-29-update-available-banner-design.md`
- Plan: `docs/superpowers/plans/2026-06-29-update-available-banner.md`

## Verification

- `npm run build` passes (type + lint).
- Manual e2e (run locally): start with `APP_VERSION=v1 npm run dev`, then restart with `APP_VERSION=v2` — banner appears within ~3s on the reconnect; Refresh reloads; plain `npm run dev` reports `"dev"` and never triggers.

## Notes

- No test runner added — matches the repo's existing test-free convention.
- The hook opens a second `/api/events` socket (intentional; the server already tracks multiple sockets per user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)